### PR TITLE
Add a trailing slash in the quickproject example

### DIFF
--- a/doc/editing-and-running.md
+++ b/doc/editing-and-running.md
@@ -145,8 +145,7 @@ $ rlwrap sbcl
 [...]
 * (ql:quickload :quickproject)
 [...]
-* (quickproject:make-project "~/Scratch/my-proj")
-WARNING: Coercing "~/Scratch/my-proj" to directory
+* (quickproject:make-project "~/Scratch/my-proj/")
 "my-proj"
 ```
 


### PR DESCRIPTION
This eliminates the warning about coercing to directory.