### PR TITLE
Various improvements to the CI infra and release process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
-stages:
-  - test
-  - package
+include:
+  - project: rigetti/ci
+    file: pipelines/docker.gitlab-ci.yml
+
+variables:
+  IMAGE: rigetti/qvm
 
 test-qvm-lib:
   stage: test
@@ -27,47 +30,3 @@ test-qvm-app:
   script:
     - make dump-version-info
     - make test-app RIGETTI_LISP_LIBRARY_HOME=/src
-
-docker-master:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  only:
-    - master
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/qvm:${CI_COMMIT_SHORT_SHA} --tag rigetti/qvm:latest .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/qvm && docker rmi -f rigetti/qvm:latest
-
-docker-branch:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  only:
-    - branches
-  except:
-    - master
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/qvm:${CI_COMMIT_REF_SLUG} .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/qvm && docker rmi -f rigetti/qvm:${CI_COMMIT_REF_SLUG}
-
-docker-vtag:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  # matches only on tags of the form vX.Y.Z
-  only:
-    - /^v(\d+\.)?(\d+\.)?(\d+)$/
-  except:
-    - branches
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/qvm:${CI_COMMIT_TAG} --tag rigetti/qvm:stable .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/qvm && docker rmi -f rigetti/qvm:stable

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# default codeowners for all files
+* @rigetti/qvm

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ system-index.txt: $(QUICKLISP_SETUP)
 ###############################################################################
 
 dump-version-info:
-	sbcl --noinform --non-interactive \
+	$(QUICKLISP) \
 		--eval '(format t "~A ~A" (lisp-implementation-type) (lisp-implementation-version))' \
 		--eval '(print (ql-dist:find-system "alexa"))' \
 		--eval '(print (ql-dist:find-system "magicl"))' \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rigetti Quantum Virtual Machine
 
+[![pipeline status](https://gitlab.com/rigetti/qvm/badges/master/pipeline.svg)](https://gitlab.com/rigetti/qvm/commits/master)
+
 This directory contains two projects. The first, `qvm`, is a classical
 implementation of the Quantum Abstract Machine (QAM), called a
 "Quantum Virtual Machine" (QVM). The second, `qvm-app`, is the
@@ -266,3 +268,42 @@ make cleanall
 ```
 
 This will delete any built executables as well.
+
+## Automated Packaging with Docker
+
+The CI pipeline for `qvm` produces a Docker image, available at
+[`rigetti/qvm`](https://hub.docker.com/r/rigetti/qvm).
+
+To get the latest stable
+version of `qvm`, run `docker pull rigetti/qvm`.
+
+## Running the QVM with Docker
+
+As outlined above, the QVM supports two modes of operation: stdin and server.
+
+To run the `qvm` in stdin mode, do the following:
+
+```shell
+echo "H 0" | docker run --rm -i rigetti/qvm -e
+```
+
+To run the `qvm` in server mode, do the following:
+
+```shell
+docker run --rm -it -p 5000:5000 rigetti/qvm -S
+```
+
+If you would like to change the port of the server to PORT, you can alter the command as follows:
+
+```shell
+docker run --rm -it -p PORT:PORT rigetti/qvm -R -p PORT
+```
+
+## Release Process
+
+1. Update `VERSION.txt` and dependency versions (if applicable) and push the commit to `master`.
+2. Push a git tag `vX.Y.Z` that contains the same version number as in `VERSION.txt`.
+3. Verify that the resulting build (triggered by pushing the tag) completes successfully.
+4. Publish a [release](https://github.com/rigetti/qvm/releases) using the tag as the name.
+5. Close the [milestone](https://github.com/rigetti/qvm/milestones) associated with this release,
+   and migrate incomplete issues to the next one.


### PR DESCRIPTION
* Include the [`rigetti/ci`](https://github.com/rigetti/ci) docker job pipeline template rather than redefining
* Add `README` notes about the [`rigetti/qvm`](https://hub.docker.com/r/rigetti/qvm) Docker image and how to use it
* Add `README` notes about the release process
* Add a `CODEOWNERS` file for default/required reviewers