### PR TITLE
QVM speaks RPCQ

### DIFF
--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -1,0 +1,95 @@
+;;;; rpc-server
+;;;;
+;;;; Author: Mark Skilbeck
+
+(in-package #:qvm-app)
+
+
+;; Let's Mock. Minimum requirements for the interface taken from
+;; handle-request.lisp: ping, version, info, multishot,
+;; multishot-measure, expectation, wavefunction.
+
+(defun get-version-info ()
+  (alexandria:alist-hash-table
+   `(("qvm" . ,+QVM-VERSION+)
+     ("githash" . ,+GIT-HASH+))))
+
+(defun get-info ()
+  (alexandria:plist-hash-table
+   (list "simulation-method" (princ-to-string *simulation-method*)
+         "shared-memory-object-name" (princ-to-string *shared-memory-object-name*)
+         "qubit-limit" (princ-to-string *qubit-limit*))
+   :test 'equal))
+
+(defun multishot (request)
+  (check-type request rpcq::|MultishotRequest|)
+  (let* ((quil-program (process-quil
+                        (safely-parse-quil-string
+                         (rpcq::|MultishotRequest-quil| request))))
+         (addresses (rpcq::|MultishotRequest-addresses| request))
+         (trials (rpcq::|MultishotRequest-trials| request))
+         (gate-noise (rpcq::|MultishotRequest-gate-noise| request))
+         (measurement-noise (rpcq::|MultishotRequest-measurement-noise| request))
+         (num-qubits (cl-quil:qubits-needed quil-program))
+         (results (perform-multishot *simulation-method* quil-program num-qubits addresses trials
+                                     :measurement-noise measurement-noise
+                                     :gate-noise gate-noise)))
+    (format-log "testing")
+    (make-instance 'rpcq::|MultishotResponse|
+                   :|results| results)))
+
+(defun multishot-measure (request)
+  (check-type request rpcq::|MultishotMeasureRequest|)
+  (multiple-value-bind (quil-program relabeling)
+      (process-quil (safely-parse-quil-string (rpcq::|MultishotMeasureRequest-quil| request)))
+    (let* ((qubits (rpcq::|MultishotMeasureRequest-qubits| request))
+           (trials (rpcq::|MultishotMeasureRequest-trials| request))
+           (num-qubits (cl-quil:qubits-needed quil-program))
+           (results (perform-multishot-measure *simulation-method* quil-program
+                                               num-qubits qubits trials
+                                               relabeling)))
+      (make-instance 'rpcq::|MultishotMeasureResponse|
+                     :|results| results))))
+
+(defun expectation (request)
+  (check-type request rpcq::|ExpectationRequest|)
+  (let* ((state-prep (safely-parse-quil-string (rpcq::|ExpectationRequest-state-preparation| request)))
+         (operators (mapcar #'safely-parse-quil-string (rpcq::|ExpectationRequest-operators| request)))
+         (gate-noise (rpcq::|ExpectationRequest-gate-noise| request))
+         (measurement-noise (rpcq::|ExpectationRequest-measurement-noise| request))         
+         (num-qubits (loop :for p :in (cons state-prep operators)
+                           :maximize (cl-quil:qubits-needed p)))
+         (results (perform-expectation *simulation-method* state-prep operators num-qubits
+                                       :gate-noise gate-noise
+                                       :measurement-noise measurement-noise)))
+    (make-instance 'rpcq::|ExpectationResponse|
+                   :|results| results)))
+
+(defun wavefunction (request)
+  (check-type request rpcq::|WavefunctionRequest|)
+  (let* ((quil (process-quil (safely-parse-quil-string (rpcq::|WavefunctionRequest-quil| request))))
+         (gate-noise (rpcq::|WavefunctionRequest-gate-noise| request))
+         (measurement-noise (rpcq::|WavefunctionRequest-measurement-noise| request))    
+         (num-qubits (cl-quil:qubits-needed quil)))
+    (let ((qvm (perform-wavefunction *simulation-method* quil num-qubits
+                                     :gate-noise gate-noise
+                                     :measurement-noise measurement-noise)))
+      (make-instance 'rpcq::|WavefunctionResponse|
+                     :|results| (coerce (qvm::amplitudes qvm) 'list))))))
+
+(declaim (special *program-name*))
+(defun start-rpc-server (&key
+                           (port 5000)
+                           (logger (make-instance 'cl-syslog:rfc5424-logger
+                                                  :log-writer (cl-syslog:null-log-writer))))
+  (let ((dt (rpcq:make-dispatch-table)))
+    (rpcq:dispatch-table-add-handler dt 'multishot)
+    (rpcq:dispatch-table-add-handler dt 'multishot-measure)
+    (rpcq:dispatch-table-add-handler dt 'expectation)
+    (rpcq:dispatch-table-add-handler dt 'wavefunction)
+    (rpcq:dispatch-table-add-handler dt 'get-version-info)
+    (rpcq:dispatch-table-add-handler dt 'get-info)
+    (rpcq:start-server :dispatch-table dt
+                       :listen-addresses (list (format nil "tcp://*:~a" port))
+                       :logger logger
+                       :timeout 60)))

--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -29,7 +29,6 @@
 (defmacro with-required-keys ((request keys) &body body)
   ""
   `(progn
-     (print ,request)
      (alexandria:if-let ((missing (apply #'missing-keys ,request ,keys)))
        (make-instance 'rpcq::|RPCError|
                       :|id| (gethash "id" ,request)

--- a/app/src/rpc-server.lisp
+++ b/app/src/rpc-server.lisp
@@ -75,7 +75,7 @@
                                      :gate-noise gate-noise
                                      :measurement-noise measurement-noise)))
       (make-instance 'rpcq::|WavefunctionResponse|
-                     :|results| (coerce (qvm::amplitudes qvm) 'list))))))
+                     :|results| (coerce (qvm::amplitudes qvm) 'list)))))
 
 (declaim (special *program-name*))
 (defun start-rpc-server (&key

--- a/qvm-app.asd
+++ b/qvm-app.asd
@@ -38,7 +38,10 @@
                ;; Portable globals
                #:global-vars
                ;; Logging
-               #:cl-syslog)
+               #:cl-syslog
+               ;; Replacing the HTTP server interface
+               #:rpcq
+               )
   :in-order-to ((asdf:test-op (asdf:test-op #:qvm-app-tests)))
   :pathname "app/src/"
   :serial t
@@ -63,4 +66,5 @@
                (:file "benchmark-programs")
                (:file "server-abstraction")
                (:file "handle-request")
-               (:file "entry-point")))
+               (:file "entry-point")
+               (:file "rpc-server")))


### PR DESCRIPTION
NOTE: requires the `qvm-speaks-rpcq` branch of my RPCQ
fork (https://github.com/notmgsk/rpcq).

Mostly working, except the wavefunction request. That's gonna require
some thinking on how to pack/serialize complex values for RPCQ.

Examples

```
CL-USER> (alexandria:hash-table-alist
          (rpcq::|MultishotResponse-results| (rpcq:with-rpc-client (client "tcp://localhost:5000")
           (rpcq:rpc-call client "multishot"
                          (make-instance 'rpcq::|MultishotRequest|
                                         :|quil| "DECLARE ro BIT[2]
DECLARE rb BIT[4]
H 0
H 1
X 2
MEASURE 0 ro[0]
MEASURE 2 rb[3]
MEASURE 2 rb[2]
MEASURE 1 rb[1]"
                                         :|addresses| (alexandria:alist-hash-table '(("ro" . (0))
                                                                                     ("rb" . (1 2 3))))
                                         :|trials| 10)))))
(("rb" (1 1 1) (1 1 1) (0 1 1) (0 1 1) (0 1 1) (0 1 1) (0 1 1) (0 1 1) (0 1 1)
  (0 1 1))
 ("ro" (0) (1) (1) (0) (0) (0) (1) (1) (0) (1)))

CL-USER> (rpcq::|MultishotMeasureResponse-results|
          (rpcq:with-rpc-client (client "tcp://localhost:5000")
           (rpcq:rpc-call client "multishot-measure"
            (make-instance 'rpcq::|MultishotMeasureRequest|
                           :|quil| "
H 0
H 1
X 2"
                           :|qubits| '(0 1 2)
                           :|trials| 10))))
((0 0 1) (0 1 1) (0 1 1) (0 1 1) (0 0 1) (0 1 1) (1 1 1) (0 1 1) (0 0 1)
 (0 1 1))

CL-USER> (rpcq::|ExpectationResponse-results|
          (rpcq:with-rpc-client (client "tcp://localhost:5000")
           (rpcq:rpc-call client "expectation"
                          (make-instance 'rpcq::|ExpectationRequest|
                                         :|state-preparation| "
H 0
"
                                         :|operators| '("X 0" "Y 0" "Z 0")))))
(0.9999999999999998d0 0.0d0 0.0d0)
```