### PR TITLE
Remove use of buildapp per #33

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,27 +54,21 @@ dump-version-info:
 # BUILD
 ###############################################################################
 
+# FOREST_SDK_OPTION *must* come last - it triggers the end of normal
+# SBCL option processing
 qvm: system-index.txt
-	buildapp --output qvm \
-                 --dynamic-space-size $(QVM_WORKSPACE) \
-                 --manifest-file system-index.txt \
-                 --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
-                 --eval '(push :hunchentoot-no-ssl *features*)' \
-		 --asdf-path . \
-                 --load-system qvm-app \
-		 $(FOREST_SDK_LOAD) \
-                 --eval '(qvm-app::zap-info)' \
-                 --eval '(qvm-app::setup-debugger)' \
-                 --compress-core \
-                 --logfile build-output.log \
-                 --entry qvm-app::%main
+	$(SBCL) $(FOREST_SDK_FEATURE) \
+	        --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
+		--eval '(push :hunchentoot-no-ssl *features*)' \
+		--load build-app.lisp \
+                $(FOREST_SDK_OPTION)
 
 qvm-sdk-base: FOREST_SDK_FEATURE=--eval '(pushnew :forest-sdk *features*)'
 qvm-sdk-base: QVM_WORKSPACE=10240
 qvm-sdk-base: clean clean-cache qvm
 
 # By default, relocate shared libraries on SDK builds
-qvm-sdk: FOREST_SDK_LOAD=--load app/src/mangle-shared-objects.lisp
+qvm-sdk: FOREST_SDK_OPTION=--qvm-sdk
 qvm-sdk: qvm-sdk-base
 
 # Don't relocate shared libraries on barebones SDK builds

--- a/app/src/mangle-shared-objects.lisp
+++ b/app/src/mangle-shared-objects.lisp
@@ -1,7 +1,6 @@
 ;;;; mangle-shared-objects.lisp
 ;;;;
-;;;; This is loaded (as with CL:LOAD) before the final image is saved
-;;;; by buildapp.
+;;;; This is loaded (as with CL:LOAD) before the final image is saved.
 ;;;;
 ;;;; Rewrites shared library references to libblas.dylib and
 ;;;; liblapack.dylib on Mac SDK targets to use the Rigetti package

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -1,0 +1,47 @@
+;;;; build-app.lisp
+;;;;
+;;;; This file is loaded by the Makefile to produce a qvm[.exe] binary.
+;;;;
+
+(unless *load-truename*
+  (error "This file is meant to be loaded."))
+
+(pushnew :hunchentoot-no-ssl *features*)
+
+(require 'asdf)
+
+(let ((*default-pathname-defaults* (make-pathname :type nil
+                                                  :name nil
+                                                  :defaults *load-truename*))
+      (output-file (make-pathname :name "qvm"
+                                  :type #+windows "exe" #-windows nil))
+      (system-table (make-hash-table :test 'equal))
+      (toplevel (lambda ()
+                  (with-simple-restart (abort "Abort")
+                    (funcall (read-from-string "qvm-app::%main")
+                             sb-ext:*posix-argv*)))))
+  (labels ((load-systems-table ()
+             (unless (probe-file "system-index.txt")
+               (error "Generate system-index.txt with 'make system-index.txt' first."))
+             (setf (gethash "qvm-app" system-table) (merge-pathnames "qvm-app.asd"))
+             (with-open-file (stream "system-index.txt")
+               (loop
+                 :for system-file := (read-line stream nil)
+                 :while system-file
+                 :do (setf (gethash (pathname-name system-file) system-table)
+                           (merge-pathnames system-file)))))
+           (local-system-search (name)
+             (values (gethash name system-table))))
+    (load-systems-table)
+    (push #'local-system-search asdf:*system-definition-search-functions*)
+    (asdf:load-system "qvm-app")
+    (funcall (read-from-string "qvm-app::zap-info"))
+    (funcall (read-from-string "qvm-app::setup-debugger"))
+    (when (find "--qvm-sdk" sb-ext:*posix-argv* :test 'string=)
+      (load "app/src/mangle-shared-objects.lisp"))
+    (sb-ext:save-lisp-and-die output-file
+                              :compression t
+                              :save-runtime-options t
+                              :executable t
+                              :toplevel toplevel)))
+

--- a/doc/lisp-setup.md
+++ b/doc/lisp-setup.md
@@ -109,26 +109,6 @@ with the path which contains the `qvm` directory.
 )
 ```
 
-## Install Buildapp
-
-Lisp is an *image-based language*. This means that almost all
-development is a stateful modification of the Lisp universe, called
-the *image*. When you want to turn your program into a binary
-executable, you have to *deliver the image*. Image delivery is best
-supported by commercial Lisp implementations such as LispWorks (which
-has all sorts of options to reduce the binary size, to optimize
-things, etc.), but it is nonetheless supported by SBCL.
-
-The easiest way to do image delivery with SBCL is through a companion
-program called *buildapp*. Installation is easy. Download buildapp
-from [here](http://www.xach.com/lisp/buildapp.tgz). Extract it and
-`cd` into it. Simply do:
-
-1. `make`
-
-2. `make DESTDIR=/where/to/install install`. If you omit the `DESTDIR`
-   setting, it'll go to `/usr/local/bin`.
-
 ## (Optional) Install Emacs and SLIME
 
 Lisp is most optimally edited in Emacs. Emacs, paired with an


### PR DESCRIPTION
Instead, use build-app.lisp file to load QVM and save the qvm
application file.

Currently only SBCL support is implemented.