### PR TITLE
Remove nil from qvm:measure calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ that both states would each come up with probability 0.5.
 * (loop :with results := (vector 0 0)
         :with program := (cl-quil:parse-quil-string "H 0")
         :repeat 100
-        :for (qvm state) := (multiple-value-list (qvm:measure (qvm:run-program 1 program) 0 nil))
+        :for (qvm state) := (multiple-value-list (qvm:measure (qvm:run-program 1 program) 0))
         :do (incf (aref results state))
         :finally (return results))
 #(54 46)

--- a/app/src/api/multishot-measure.lisp
+++ b/app/src/api/multishot-measure.lisp
@@ -27,7 +27,7 @@
            :if (eql q ':unused-qubit)
              :collect 0
            :else
-             :collect (nth-value 1 (qvm:measure qvm q nil))))))
+             :collect (nth-value 1 (qvm:measure qvm q))))))
 
 (defgeneric perform-multishot-measure (simulation-method quil num-qubits qubits num-trials relabeling)
   (:method (simulation-method quil num-qubits qubits num-trials relabeling)


### PR DESCRIPTION
This parameter was removed by a previous
PR (https://github.com/rigetti/qvm/pull/23).