### PR TITLE
initial interface for different kinds of allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,28 @@ $ make qvm
 
 This will produce a binary executable `qvm` in the same directory.
 
-In some situtations, using a large number of qubits may caus heap
-exhaustion. To increase the memory available for the QVM, recompile
+In some situtations, using a large number of qubits may cause heap
+exhaustion. There are two options to ameliorate this.
+
+The first is to increase the memory available for the QVM, recompile
 and specify the workspace size (in MB)
 
 ```
 $ make QVM_WORKSPACE=4096 qvm
 ```
+
+The second is to use a different allocator when running the QVM, by
+using the `--default-allocator` argument with `"foreign"`. For
+example, to run a 30 qubit benchmark on a QVM configured for far less
+memory, one can do:
+
+```
+$ qvm --default-allocator "foreign" --benchmark 30 -c
+```
+
+This is *not* the default since this memory is not fully managed by
+the application.
+
 
 The QVM application has a few command-line switches used to configure
 the QVM. To explore those options, see the output of the following command:

--- a/app/src/benchmark-programs.lisp
+++ b/app/src/benchmark-programs.lisp
@@ -71,7 +71,8 @@ We are assuming the CNOTs are dense on an even number of qubits."
                  ("qft"  (qft-program num-qubits))
                  ("hadamard" (hadamard-program num-qubits))
                  ("qualcs" (qualcs-program num-qubits))))
-            (q (qvm:make-qvm num-qubits))
+            (q (qvm:make-qvm num-qubits
+                             :allocation (funcall **default-allocation** (expt 2 num-qubits))))
             timing)
         (qvm:load-program q p :supersede-memory-subsystem t)
 

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -16,8 +16,15 @@
 (defparameter *available-simulation-methods* '("pure-state" "full-density-matrix")
   "List of available simulation methods.")
 
+(defparameter *available-allocation-kinds* '("native" "foreign")
+  "Kinds of allocations that are possible.")
+
 (defparameter *option-spec*
-  `((("execute" #\e)
+  `((("default-allocation")
+     :type string
+     :initial-value "native"
+     :documentation "select where wavefunctions get allocated: \"native\" (default) for native allocation, \"foreign\" for C-compatible allocation")
+    (("execute" #\e)
      :type boolean
      :optional t
      :documentation "read a Quil program from stdin and execute it (DEPRECATED: simply elide this option)")
@@ -239,13 +246,17 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
 
 (defmethod make-shared-wavefunction ((simulation-method (eql 'pure-state)) num-qubits name)
   (multiple-value-bind (vec finalizer)
-      (qvm::make-shared-array name (expt 2 num-qubits) 'qvm:cflonum)
+      (qvm:allocate-vector (make-instance 'qvm:posix-shared-memory-allocation
+                                          :name name
+                                          :length (expt 2 num-qubits)))
     (setf (aref vec 0) (cflonum 1))
     (values vec finalizer)))
 
 (defmethod make-shared-wavefunction ((simulation-method (eql 'full-density-matrix)) num-qubits name)
     (multiple-value-bind (vec finalizer)
-        (qvm::make-shared-array name (expt 2 (* 2 num-qubits)) 'qvm:cflonum)
+        (qvm:allocate-vector (make-instance 'qvm:posix-shared-memory-allocation
+                                            :name name
+                                            :length (expt 2 (* 2 num-qubits))))
       ;; It just so happens that the pure zero state in the
       ;; density matrix formalism is the same as the pure zero state
       ;; in the state-vector formalism)
@@ -273,9 +284,24 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
                 memories)))
     (terpri)))
 
+(defun allocation-description-maker (kind)
+  "Return a function INTEGER -> ALLOCATION that takes a number of elements and returns a proper descriptor for the allocation."
+  (cond
+    ((string-equal kind "native")
+     (lambda (length)
+       (make-instance 'qvm:lisp-allocation :length length)))
+    ((string-equal kind "foreign")
+     (lambda (length)
+       (make-instance 'qvm:c-allocation :length length)))
+    (t
+     (error "Invalid kind of allocation ~S, wanted any of {~{~S~^, ~}"
+            kind
+            *available-allocation-kinds*))))
+
 (defun process-options (&key version
                              check-libraries
                              verbose
+                             default-allocation
                              execute
                              help
                              memory-limit
@@ -307,6 +333,9 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
 
   (when verbose
     (setf qvm:*transition-verbose* t))
+
+  (when default-allocation
+    (setq **default-allocation** (allocation-description-maker default-allocation)))
 
   (when (plusp time-limit)
     (setf *time-limit* (/ time-limit 1000.0d0)))
@@ -445,7 +474,9 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
        ;; Allocate the QVM.
        (format-log "Allocating memory for QVM of ~D qubits." qubits-needed)
        (with-timing (alloc-time)
-         (setf qvm (make-qvm qubits-needed)))
+         (setf qvm (make-qvm qubits-needed
+                             :allocation (funcall **default-allocation**
+                                                  (expt 2 qubits-needed)))))
        (format-log "Allocation completed in ~D ms." alloc-time)
 
        ;; Load our program.

--- a/app/src/globals.lisp
+++ b/app/src/globals.lisp
@@ -15,6 +15,9 @@
 (global-vars:define-global-var **persistent-wavefunction** nil)
 (global-vars:define-global-var **persistent-wavefunction-finalizer** (constantly nil))
 
+(global-vars:define-global-var **default-allocation**
+    (lambda (n) (make-instance 'qvm:lisp-allocation :length n)))
+
 (deftype simulation-method ()
   "Available QVM simulation methods."
   `(member pure-state full-density-matrix))

--- a/app/tests/suite.lisp
+++ b/app/tests/suite.lisp
@@ -35,22 +35,22 @@ MEASURE 1 ro[1]"))
          (readout-povm (aref code 2))
          (measure (aref code 3)))
     ;; test gate application remapped
-    (is (= 0
-           (cl-quil:qubit-index
-            (first (cl-quil:application-arguments gate-app)))))
+    (is (zerop
+         (cl-quil:qubit-index
+          (first (cl-quil:application-arguments gate-app)))))
     ;; test kraus pragma remapped
-    (is (= 0
-           (first (cl-quil:pragma-qubit-arguments add-kraus))))
+    (is (zerop
+         (first (cl-quil:pragma-qubit-arguments add-kraus))))
     ;; test readout noise pragma remapped
-    (is (= 0
-           (cl-quil:pragma-qubit-index readout-povm)))
+    (is (zerop
+         (cl-quil:pragma-qubit-index readout-povm)))
     ;; test types of povm probabilities
     (is (typep (first (cl-quil:pragma-matrix-entries readout-povm))
                'double-float))
     ;; test measurement qubit remapped
-    (is (= 0
-           (cl-quil:qubit-index
-            (cl-quil:measurement-qubit measure))))))
+    (is (zerop
+         (cl-quil:qubit-index
+          (cl-quil:measurement-qubit measure))))))
 
 (deftest test-multishot-measure-remapping ()
   (dolist (simulation-method '(qvm-app::pure-state qvm-app::full-density-matrix))

--- a/doc/man/qvm.1
+++ b/doc/man/qvm.1
@@ -41,6 +41,13 @@ evolution) may be specified by the --simulation-method flag.
 The QVM does not have explicit options for running programs with noise
 models. Instead, the Quil program itself specifies PRAGMAs for
 defining Kraus operators and readout POVMs.
+
+The wavefunctions are allocated into a managed memory space by
+default, where garbage collection can occur. This means, however, that
+the size of this space (and thus the maximum number of qubits) must be
+specified when the QVM application was compiled. By using an
+alternative default allocation mode (i.e., by setting
+--default-allocation) such as "foreign", one can bypass this limit.
 .SH OPTIONS
 .IP "-e, --execute"
 (DEPRECATED; Execute Mode is the default.) Run the QVM in Execute
@@ -85,6 +92,13 @@ the evolved wavefunction.
 JIT compile the Quil programs to make them run faster.
 .IP "--safe-include-directory <dir>"
 Restrict the Quil INCLUDE directive exclusively to <dir>.
+.IP "default-allocation" <alloc-kind>
+Select where wavefunctions get allocated. The argument <alloc-kind>
+can either be "native" (default) for native allocation, or "foreign"
+for C-compatible allocation. The benefit of C-compatible allocation is
+that the compiled heap size (as specified by QVM_WORKSPACE at
+compile-time) does not limit the wavefunction size, but may lead to less
+predictable memory performance.
 .IP "--shared <name>"
 (Server Mode) Run the QVM in shared memory mode. This allocates the
 wavefunction in POSIX shared memory named <name>. If <name> is an
@@ -298,6 +312,8 @@ Benchmark a 25-qubit quantum Fourier transform in compiled mode.
 .SH BUGS
 Shared memory mode does not work with QVMs executing noisy programs
 (i.e., ones where Kraus operators or POVMs are specified).
+
+The allocation mode is not reflected in density matrix simulations.
 
 The WAIT instruction does nothing.
 .SH SUPPORT

--- a/dqvm/src/worker.lisp
+++ b/dqvm/src/worker.lisp
@@ -50,12 +50,12 @@
 (defun allocate-worker (cluster)
   "Allocate memory for the worker suitable for the cluster CLUSTER."
   (make-worker :rank +my-rank+
-               :work-area (let ((v (qvm::make-vector (area-length cluster))))
+               :work-area (let ((v (qvm::make-lisp-cflonum-vector (area-length cluster))))
                             ;; Set to |000...00>.
                             (when (= 1 +my-rank+)
                               (setf (aref v 0) (qvm:cflonum 1)))
                             v)
-               :copy-area (qvm::make-vector (area-length cluster))))
+               :copy-area (qvm::make-lisp-cflonum-vector (area-length cluster))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;; Reorg Amplitudes ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -371,7 +371,7 @@
   (declare (optimize speed (safety 0) (debug 0)))
   (let* ((block-length (block-length cluster (operating-qubits cluster)))
          (work-area (work-area worker))
-         (column (qvm::make-vector block-length)))
+         (column (qvm::make-lisp-cflonum-vector block-length)))
     (declare (type (simple-array qvm:cflonum (*)) work-area)
              (type (and fixnum unsigned-byte) block-length))
     (loop :for blk :below (the fixnum (area-length cluster)) :by block-length :do

--- a/qvm.asd
+++ b/qvm.asd
@@ -25,7 +25,9 @@
                #:global-vars
                ;; C foreign function interface
                #:cffi
+               ;; Allocation of C vectors
                (:version #:static-vectors "1.8.3")
+               ;; Finalizers and portable GC calls
                #:trivial-garbage
                ;; Quil parsing and analysis
                (:version #:cl-quil "1.5.0")
@@ -45,8 +47,10 @@
                (:file "impl/clozure" :if-feature :clozure)
                (:file "impl/sbcl" :if-feature :sbcl)
                (:file "impl/lispworks" :if-feature :lispworks)
-               (:file "shm" :if-feature :unix)
                (:file "utilities")
+               (:file "floats")
+               (:file "allocator")
+               (:file "shm" :if-feature :unix)
                (:file "linear-algebra")
                (:file "qam")
                (:file "classical-memory")

--- a/qvm.asd
+++ b/qvm.asd
@@ -33,7 +33,8 @@
                (:version #:cl-quil "1.5.0")
                ;; Portable random number generator
                #:mt19937
-               )
+               ;; For allocation info.
+               #+sbcl #:sb-introspect)
   :in-order-to ((asdf:test-op (asdf:test-op #:qvm-tests)))
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))

--- a/src/allocator.lisp
+++ b/src/allocator.lisp
@@ -43,9 +43,9 @@
 (declaim (ftype (function (t) (values cflonum-vector finalizer))
                 allocate-vector))
 (defgeneric allocate-vector (description)
-  (:documentation "Allocate a fresh zero-initialized QUANTUM-STATE vector described by DESCRIPTION. Return two values:
+  (:documentation "Allocate a fresh zero-initialized CFLONUM-VECTOR described by DESCRIPTION. Return two values:
 
-    1. The allocated vector (a QUANTUM-STATE).
+    1. The allocated vector (a CFLONUM-VECTOR).
 
     2. A finalizer thunk of type FINALIZER, which should be called when the memory is OK to be freed.
 

--- a/src/allocator.lisp
+++ b/src/allocator.lisp
@@ -1,0 +1,103 @@
+;;;; allocator.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:qvm)
+
+;;; This file manages the allocation of CFLONUM vectors in different
+;;; spaces.
+;;;
+;;; There are two components to this file: allocation descriptions,
+;;; and the allocation method.
+;;;
+;;; Allocation descriptions describe how much memory to allocate and
+;;; where. It's all specialized on CFLONUM-VECTORs right now, since
+;;; that's mostly all the QVM uses. These are implemented as classes,
+;;; that at least have some sort of ALLOCATION-LENGTH method to
+;;; indicate how many CFLONUMs should be allocated.
+;;;
+;;; The allocation method is ALLOCATE-VECTOR. This method is
+;;; specialized on the aforementioned types. Critically, this method
+;;; provides both the allocated data, as well as some finalizing
+;;; function to free the memory. Since data might be allocated
+;;; somewhere else besides the managed Lisp heap, it's up to you, the
+;;; programmer, to call the freeing function. (Save us the trouble and
+;;; don't cheat! Even with LISP-ALLOCATION vectors! If you decide to
+;;; change your mind later you'll regret it! If you don't want to use
+;;; the allocation interface, use MAKE-LISP-CFLONUM-VECTOR.)
+;;;
+;;; Note that not all ALLOCATE-VECTOR specializations live in
+;;; this file.
+
+(deftype finalizer ()
+  "A finalizer thunk. Used for the effect of freeing some memory."
+  '(function () nil))
+
+(defun dummy-finalizer ()
+  "A \"finalizer\" that does nothing. Used for objects managed by the GC."
+  nil)
+
+;;; If we made this declaration on the DEFGENERIC, the type would get
+;;; clobbered.
+#+#:ignore
+(declaim (ftype (function (t) (values cflonum-vector finalizer))
+                allocate-vector))
+(defgeneric allocate-vector (description)
+  (:documentation "Allocate a fresh zero-initialized QUANTUM-STATE vector described by DESCRIPTION. Return two values:
+
+    1. The allocated vector (a QUANTUM-STATE).
+
+    2. A finalizer thunk of type FINALIZER, which should be called when the memory is OK to be freed.
+
+NOTE: Note that the finalizer may close over the allocated vector."))
+
+;;; If we made this declaration on the DEFGENERIC, the type would get
+;;; clobbered.
+#+#:ignore
+(declaim (ftype (function (t) non-negative-fixnum) allocation-length))
+(defgeneric allocation-length (description)
+  (:documentation "The length of memory to be allocated, measured in the element type of the vector."))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;; Lisp Heap Allocation ;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defclass lisp-allocation ()
+  ((length :initarg :length :reader allocation-length))
+  (:documentation "A description of an allocation on the Lisp heap."))
+
+(declaim (inline make-lisp-cflonum-vector))
+(defun make-lisp-cflonum-vector (length)
+  (make-array length
+              :element-type 'cflonum
+              :initial-element (cflonum 0)))
+
+(defmethod allocate-vector ((descr lisp-allocation))
+  (values (make-lisp-cflonum-vector (allocation-length descr))
+          #'dummy-finalizer))
+
+
+;;;;;;;;;;;;;;;;;;;;; Foreign Memory Allocation ;;;;;;;;;;;;;;;;;;;;;;
+
+(defclass c-allocation ()
+  ((length :initarg :length :reader allocation-length))
+  (:documentation "A description of an allocation in foreign memory."))
+
+(defmethod allocate-vector ((descr c-allocation))
+  (let ((vec (static-vectors:make-static-vector (allocation-length descr)
+                                                :element-type 'cflonum
+                                                :initial-element (cflonum 0))))
+    (values vec
+            (lambda ()
+              (static-vectors:free-static-vector vec)
+              nil))))
+
+
+;;;;;;;;;;;;;;;;;;; POSIX Shared Memory Allocation ;;;;;;;;;;;;;;;;;;;
+
+(defclass posix-shared-memory-allocation ()
+  ((length :initarg :length :reader allocation-length)
+   (name :initarg :name :reader allocation-name))
+  (:documentation "A description of an allocation in POSIX shared memory."))
+
+;;; ALLOCATE-VECTOR for this class is defined in "shm.lisp", which is
+;;; conditional on being a UNIX OS.

--- a/src/allocator.lisp
+++ b/src/allocator.lisp
@@ -16,15 +16,16 @@
 ;;; that at least have some sort of ALLOCATION-LENGTH method to
 ;;; indicate how many CFLONUMs should be allocated.
 ;;;
-;;; The allocation method is ALLOCATE-VECTOR. This method is
-;;; specialized on the aforementioned types. Critically, this method
-;;; provides both the allocated data, as well as some finalizing
-;;; function to free the memory. Since data might be allocated
-;;; somewhere else besides the managed Lisp heap, it's up to you, the
-;;; programmer, to call the freeing function. (Save us the trouble and
-;;; don't cheat! Even with LISP-ALLOCATION vectors! If you decide to
-;;; change your mind later you'll regret it! If you don't want to use
-;;; the allocation interface, use MAKE-LISP-CFLONUM-VECTOR.)
+;;; The allocation generic function is ALLOCATE-VECTOR. This function
+;;; is specialized on the aforementioned types. Critically, this
+;;; function provides both the allocated data, as well as some
+;;; finalizing function to free the memory. Since data might be
+;;; allocated somewhere else besides the managed Lisp heap, it's up to
+;;; you, the programmer, to call the freeing function. (Save us the
+;;; trouble and don't cheat! Even with LISP-ALLOCATION vectors! If you
+;;; decide to change your mind later you'll regret it! If you don't
+;;; want to use the allocation interface, use
+;;; MAKE-LISP-CFLONUM-VECTOR.)
 ;;;
 ;;; Note that not all ALLOCATE-VECTOR specializations live in
 ;;; this file.
@@ -38,7 +39,8 @@
   nil)
 
 ;;; If we made this declaration on the DEFGENERIC, the type would get
-;;; clobbered.
+;;; clobbered. We put this type here anyway, albeit commented out, so
+;;; you know what the *real* type of this function should be.
 #+#:ignore
 (declaim (ftype (function (t) (values cflonum-vector finalizer))
                 allocate-vector))
@@ -52,7 +54,8 @@
 NOTE: Note that the finalizer may close over the allocated vector."))
 
 ;;; If we made this declaration on the DEFGENERIC, the type would get
-;;; clobbered.
+;;; clobbered. We put this type here anyway, albeit commented out, so
+;;; you know what the *real* type of this function should be.
 #+#:ignore
 (declaim (ftype (function (t) non-negative-fixnum) allocation-length))
 (defgeneric allocation-length (description)

--- a/src/density-qvm.lisp
+++ b/src/density-qvm.lisp
@@ -86,7 +86,7 @@ recorded outcome j may be different."))
   qvm)
 
 
-(defun make-density-qvm (num-qubits &rest args)
+(defun make-density-qvm (num-qubits &rest initargs)
   ;; The amplitudes store vec(ρ), i.e. the entries of the density
   ;; matrix ρ in row-major order. For a system of N qubits, ρ has
   ;; dimension 2^N x 2^N, hence a total of 2^(2N) entries.
@@ -96,11 +96,13 @@ recorded outcome j may be different."))
   ;; position. See also RESET-QUANTUM-STATE, which we avoid
   ;; calling here because it performs an additional full traversal
   ;; of the vector.                
-  (let ((amplitudes (make-vector (expt 2 (* 2 num-qubits)) 1)))
+  (let ((amplitudes (make-lisp-cflonum-vector (expt 2 (* 2 num-qubits)))))
+    ;; Go into the zero state.
+    (setf (aref amplitudes 0) (cflonum 1))
     (apply #'make-instance 'density-qvm
            :number-of-qubits num-qubits
            :amplitudes amplitudes
-           args)))
+           initargs)))
 
 (defun full-density-number-of-qubits (vec-density)
   "Computes the number of qubits encoded by a vectorized density matrix."

--- a/src/floats.lisp
+++ b/src/floats.lisp
@@ -47,5 +47,5 @@
       (coerce x 'cflonum)
       whole))
 
-(deftype cflonum-vector ()
-  `(simple-array cflonum (*)))
+(deftype cflonum-vector (&optional (length '*))
+  `(simple-array cflonum (,length)))

--- a/src/floats.lisp
+++ b/src/floats.lisp
@@ -12,11 +12,12 @@
 
 (defconstant +octets-per-flonum+ 8)
 
-(deftype flonum (&optional min)
+(deftype flonum (&optional (min '*))
   "The float type used in computations."
-  (if (numberp min)
-      `(double-float ,(coerce min 'double-float))
-      `double-float))
+  (cond
+    ((numberp min) `(double-float ,(coerce min 'double-float)))
+    ((eq '* min)   `double-float)
+    (t (error "Malformed type: (FLONUM ~S)" min))))
 
 (defconstant +octets-per-cflonum+ (* 2 +octets-per-flonum+))
 
@@ -34,8 +35,8 @@
       (coerce x 'flonum)
       whole))
 
-(deftype flonum-vector ()
-  `(simple-array flonum (*)))
+(deftype flonum-vector (&optional (length '*))
+  `(simple-array flonum (,length)))
 
 (defun cflonum (x)
   "Coerce X into a CFLONUM."

--- a/src/floats.lisp
+++ b/src/floats.lisp
@@ -12,7 +12,7 @@
 
 (defconstant +octets-per-flonum+ 8)
 
-(deftype flonum (&optional (min '*))
+(deftype flonum (&optional min)
   "The float type used in computations."
   (cond
     ((numberp min) `(double-float ,(coerce min 'double-float)))
@@ -35,7 +35,7 @@
       (coerce x 'flonum)
       whole))
 
-(deftype flonum-vector (&optional (length '*))
+(deftype flonum-vector (&optional length)
   `(simple-array flonum (,length)))
 
 (defun cflonum (x)
@@ -48,5 +48,5 @@
       (coerce x 'cflonum)
       whole))
 
-(deftype cflonum-vector (&optional (length '*))
+(deftype cflonum-vector (&optional length)
   `(simple-array cflonum (,length)))

--- a/src/floats.lisp
+++ b/src/floats.lisp
@@ -1,0 +1,51 @@
+;;;; floats.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:qvm)
+
+;;; This file deals with the different floating point representations
+;;; made use of in the QVM.
+;;;
+;;; These are agreed upon *everywhere* in the QVM. These are allowed
+;;; to change, but only here.
+
+(defconstant +octets-per-flonum+ 8)
+
+(deftype flonum (&optional min)
+  "The float type used in computations."
+  (if (numberp min)
+      `(double-float ,(coerce min 'double-float))
+      `double-float))
+
+(defconstant +octets-per-cflonum+ (* 2 +octets-per-flonum+))
+
+(deftype cflonum ()
+  "The complex float type used in computations. Typically these will represent wavefunction amplitudes."
+  `(complex flonum))
+
+(defun flonum (x)
+  "Coerce X into a FLONUM."
+  (coerce x 'flonum))
+
+(define-compiler-macro flonum (&whole whole &environment env x)
+  (if (and (constantp x env)
+           (numberp x))
+      (coerce x 'flonum)
+      whole))
+
+(deftype flonum-vector ()
+  `(simple-array flonum (*)))
+
+(defun cflonum (x)
+  "Coerce X into a CFLONUM."
+  (coerce x 'cflonum))
+
+(define-compiler-macro cflonum (&whole whole &environment env x)
+  (if (and (constantp x env)
+           (numberp x))
+      (coerce x 'cflonum)
+      whole))
+
+(deftype cflonum-vector ()
+  `(simple-array cflonum (*)))

--- a/src/impl/sbcl.lisp
+++ b/src/impl/sbcl.lisp
@@ -25,5 +25,5 @@ clean up that vector."
     (declare (ignore n-bits))
     (values (static-vectors::vector-from-pointer pointer widetag num-elements)
             ;; No finalizer is needed for the vector itself in SBCL.
-            (constantly nil))))
+            (lambda () nil))))
 

--- a/src/noisy-qvm.lisp
+++ b/src/noisy-qvm.lisp
@@ -230,7 +230,7 @@ POVM must be a 4-element list of double-floats."))
          ;; Avoid unnecessary copying by swapping pointers to
          ;; amplitudes and trial-amplitudes. However, whenever we have
          ;; finished RUNning a program, we should get the amplitudes
-         ;; back into original memory. See the :AROUND method above.
+         ;; back into original memory. See the :AFTER method above.
          (rotatef (amplitudes qvm) (%trial-amplitudes qvm))
 
          (normalize-wavefunction (amplitudes qvm))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -35,6 +35,7 @@
 
   ;; allocator.lisp
   (:export
+   #:allocation-length                  ; GENERIC, METHOD
    #:allocate-vector                    ; GENERIC, METHOD
    #:lisp-allocation                    ; CLASS
    #:c-allocation                       ; CLASS

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -27,12 +27,24 @@
    #:with-random-state                  ; MACRO
    )
 
+  ;; floats.lisp
+  (:export
+   #:flonum                             ; TYPE, FUNCTION, COMPILER MACRO
+   #:cflonum                            ; TYPE, FUNCTION, COMPILER MACRO
+   )
+
+  ;; allocator.lisp
+  (:export
+   #:allocate-vector                    ; GENERIC, METHOD
+   #:lisp-allocation                    ; CLASS
+   #:c-allocation                       ; CLASS
+   #:posix-shared-memory-allocation     ; CLASS
+   )
+
   ;; linear-algebra.lisp
   (:export
    #:quantum-operator                   ; TYPE
    #:quantum-state                      ; TYPE
-   #:flonum                             ; TYPE, FUNCTION, COMPILER MACRO
-   #:cflonum                            ; TYPE, FUNCTION, COMPILER MACRO
    #:octets-required-for-qubits         ; FUNCTION
    )
 

--- a/src/qvm.lisp
+++ b/src/qvm.lisp
@@ -76,7 +76,7 @@
        ;;
        ;; We explicitly zero out the memory to make sure all pages get
        ;; touched.
-       (setf (slot-value qvm 'amplitudes) (make-vector (expt 2 num-qubits)))
+       (setf (slot-value qvm 'amplitudes) (make-lisp-cflonum-vector (expt 2 num-qubits)))
        (bring-to-zero-state (amplitudes qvm))))))
 
 

--- a/src/wavefunction.lisp
+++ b/src/wavefunction.lisp
@@ -48,7 +48,7 @@
   v)
 
 (defun copy-wavefunction (wf &optional destination)
-  "Create a copy of the wavefunction WF. If DESTINATION is provided, copy the wavefunction WF into the DESTINATION vector. Only copy as many elements as can be copied, namely min(|wf|, |destination|)."
+  "Create a copy of the wavefunction WF. If DESTINATION is NIL, allocate a new vector on the Lisp heap. If DESTINATION is provided, copy the wavefunction WF into the DESTINATION vector. Only copy as many elements as can be copied, namely min(|wf|, |destination|)."
   (declare (type quantum-state wf)
            (type (or null quantum-state) destination))
   (let ((length (if (null destination)
@@ -56,7 +56,7 @@
                     (min (length wf) (length destination)))))
     (if (<= *qubits-required-for-parallelization* (1- (integer-length length)))
         (let ((copy (if (null destination)
-                        (make-vector length) ; Allocate fresh vector.
+                        (make-lisp-cflonum-vector length) ; Allocate fresh vector.
                         destination)))
           (declare (type quantum-state copy))
           (lparallel:pdotimes (i length copy)
@@ -163,7 +163,7 @@ up to amplitude ordering."
   (declare (type nat-tuple qubits)
            (type quantum-state wavefunction)
            (inline map-reordered-amplitudes))
-  (let ((col (make-vector (expt 2 (nat-tuple-cardinality qubits)))))
+  (let ((col (make-lisp-cflonum-vector (expt 2 (nat-tuple-cardinality qubits)))))
     (flet ((extract (combo address)
              (setf (aref col combo) (aref wavefunction address))
              nil))
@@ -196,7 +196,7 @@ up to amplitude ordering."
       `(locally (declare (type nat-tuple ,qubits)
                          (type quantum-state ,wavefunction)
                          (inline map-reordered-amplitudes))
-         (let ((,col (make-vector (expt 2 (nat-tuple-cardinality ,qubits)))))
+         (let ((,col (make-lisp-cflonum-vector (expt 2 (nat-tuple-cardinality ,qubits)))))
            (declare (type quantum-state ,col)
                     (dynamic-extent ,col))
            (flet ((,extract (,combo ,address)

--- a/tests/linear-algebra-tests.lisp
+++ b/tests/linear-algebra-tests.lisp
@@ -5,10 +5,10 @@
 (in-package #:qvm-tests)
 
 (defun random-wavefunction (&optional (size 8))
-  (map-into (qvm::make-vector size) (lambda ()
-                                      (cflonum
-                                       (complex (random 1.0d0)
-                                                (random 1.0d0))))))
+  (map-into (make-vector size) (lambda ()
+                                 (cflonum
+                                  (complex (random 1.0d0)
+                                           (random 1.0d0))))))
 
 
 (defun naive-sum (f v)
@@ -65,11 +65,11 @@
 
 (deftest test-cdf ()
   "Test that CUMULATIVE-DISTRIBUTION-FUNCTION seems to work."
-  (is (every #'double-float= #() (qvm::cumulative-distribution-function (qvm::make-vector 0))))
+  (is (every #'double-float= #() (qvm::cumulative-distribution-function (make-vector 0))))
   (is (every #'double-float= #(1.0d0 2.0d0 3.0d0) (qvm::cumulative-distribution-function
-                                                   (qvm::make-vector 3 1 1 1))))
+                                                   (make-vector 3 1 1 1))))
   (is (every #'double-float= #(0.5d0 1.0d0 1.5d0) (qvm::cumulative-distribution-function
-                                                   (qvm::make-vector 3
-                                                                     (sqrt 1/2)
-                                                                     (sqrt 1/2)
-                                                                     (sqrt 1/2))))))
+                                                   (make-vector 3
+                                                                (sqrt 1/2)
+                                                                (sqrt 1/2)
+                                                                (sqrt 1/2))))))

--- a/tests/measurement-tests.lisp
+++ b/tests/measurement-tests.lisp
@@ -133,7 +133,7 @@
 (deftest test-sample-wavefunction ()
   "Test that we can sample from a wavefunction correctly."
   (flet ((test-vector (&rest args)
-           (apply #'qvm::make-vector
+           (apply #'make-vector
                   (length args)
                   (mapcar #'sqrt args))))
     ;; Simple uniform test.

--- a/tests/noisy-qvm-tests.lisp
+++ b/tests/noisy-qvm-tests.lisp
@@ -7,8 +7,9 @@
 
 (defun check-noisy-pointer-is-correct (qvm)
   (when (typep qvm 'qvm:noisy-qvm)
-    (is (eq (qvm::amplitudes qvm)
-            (qvm::original-amplitude-pointer qvm)))))
+    (is (or (not (qvm::requires-swapping-p qvm))
+            (eq (qvm::amplitudes qvm)
+                (qvm::original-amplitude-pointer qvm))))))
 
 (deftest test-empty-program-depolarizing-qvm ()
   (let ((p (with-output-to-quil))

--- a/tests/stress-tests.lisp
+++ b/tests/stress-tests.lisp
@@ -9,7 +9,7 @@
 
 (deftest test-qvm-garbage-collection ()
   "Test that large QVMs get garbage collected and do so without erroring."
-  (format t "[Test output: ") (finish-output)
+  (format t "~&[Test output: ") (finish-output)
   (tg:gc :full t)
   (loop :with big-qubit-amount := 23
         ;; This should allocate about
@@ -32,7 +32,7 @@
 (deftest test-posix-shared-memory-allocation/deallocation ()
   "Test allocation and deallocation of large blocks of POSIX shared memory. This test may result in total system failure."
   (run-unless-environment-has "DISABLE_SHARED_MEMORY_QVM_TESTS"
-    (format t "[Test output: ") (finish-output)
+    (format t "~&[Test output: ") (finish-output)
     (let ((len (* 2 1024 1024 1024)))
       (flet ((write-ones (shm)
                (cffi:foreign-funcall
@@ -59,7 +59,7 @@
 (deftest test-shared-array-allocation/deallocation ()
   "Make sure allocation and deallocation of shared arrays works."
   (run-unless-environment-has "DISABLE_SHARED_MEMORY_QVM_TESTS"
-    (format t "[Test output: ") (finish-output)
+    (format t "~&[Test output: ") (finish-output)
     (tg:gc :full t)
     (flet ((write-ones (array)
              (declare (optimize speed (safety 0) (debug 0) (space 0) (compilation-speed 0))
@@ -87,7 +87,7 @@
 (deftest test-shared-qvm-garbage-collection ()
   "Test that large shared QVMs get garbage collected and do so without erroring."
   (run-unless-environment-has "DISABLE_SHARED_MEMORY_QVM_TESTS"
-    (format t "[Test output: ") (finish-output)
+    (format t "~&[Test output: ") (finish-output)
     (tg:gc :full t)
     (loop :with big-qubit-amount := 26
           ;; This should allocate about

--- a/tests/stress-tests.lisp
+++ b/tests/stress-tests.lisp
@@ -137,8 +137,9 @@
     ;; Keep allocations localized in the lexical environment below.
     (let ((a (make-instance 'dummy-allocation)))
       (loop
-        ;; Boot stuff off to the next page.
-        :with junk := (make-array (1+ (qvm::getpagesize))
+        ;; Boot stuff off to the next page/card.
+        :with junk := (make-array #+sbcl (1+ sb-vm:gencgc-card-bytes)
+                                  #-sbcl (1+ (* 8 (qvm::getpagesize)))
                                   :element-type '(unsigned-byte 8)
                                   :initial-element 0)
         :repeat num-loops
@@ -150,7 +151,8 @@
       ;; Do some allocation of at least 5 quarter page sizes to kick us
       ;; off to a new page since SBCL marks garbage on a page-per-page
       ;; basis.
-      (loop :with alloc-size := (1- (qvm::getpagesize))
+      (loop :with alloc-size := #+sbcl (1- sb-vm:gencgc-card-bytes)
+                                #-sbcl (1- (* 8 (qvm::getpagesize)))
             :repeat 1000
             :do (make-array alloc-size :element-type '(unsigned-byte 8)
                                        :initial-element 0)))

--- a/tests/stress-tests.lisp
+++ b/tests/stress-tests.lisp
@@ -9,7 +9,7 @@
 
 (deftest test-qvm-garbage-collection ()
   "Test that large QVMs get garbage collected and do so without erroring."
-  (format t "~&[Test output: ") (finish-output)
+  (format t "~&    [Test output: ") (finish-output)
   (tg:gc :full t)
   (loop :with big-qubit-amount := 23
         ;; This should allocate about
@@ -32,7 +32,7 @@
 (deftest test-posix-shared-memory-allocation/deallocation ()
   "Test allocation and deallocation of large blocks of POSIX shared memory. This test may result in total system failure."
   (run-unless-environment-has "DISABLE_SHARED_MEMORY_QVM_TESTS"
-    (format t "~&[Test output: ") (finish-output)
+    (format t "~&    [Test output: ") (finish-output)
     (let ((len (* 2 1024 1024 1024)))
       (flet ((write-ones (shm)
                (cffi:foreign-funcall
@@ -59,7 +59,7 @@
 (deftest test-shared-array-allocation/deallocation ()
   "Make sure allocation and deallocation of shared arrays works."
   (run-unless-environment-has "DISABLE_SHARED_MEMORY_QVM_TESTS"
-    (format t "~&[Test output: ") (finish-output)
+    (format t "~&    [Test output: ") (finish-output)
     (tg:gc :full t)
     (flet ((write-ones (array)
              (declare (optimize speed (safety 0) (debug 0) (space 0) (compilation-speed 0))
@@ -87,7 +87,7 @@
 (deftest test-shared-qvm-garbage-collection ()
   "Test that large shared QVMs get garbage collected and do so without erroring."
   (run-unless-environment-has "DISABLE_SHARED_MEMORY_QVM_TESTS"
-    (format t "~&[Test output: ") (finish-output)
+    (format t "~&    [Test output: ") (finish-output)
     (tg:gc :full t)
     (loop :with big-qubit-amount := 26
           ;; This should allocate about
@@ -167,7 +167,7 @@
             :do (make-array alloc-size :element-type '(unsigned-byte 8)
                                        :initial-element 0)))
     ;; Now garbage collect, hopefully hitting all of the finalizers.
-    (format t "~&[GCing... ") (finish-output)
+    (format t "~&    [GCing... ") (finish-output)
     (tg:gc :full t)
 
     ;; We sleep to try to hit all finalizers. Stuff might be happening

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -150,3 +150,10 @@ In general, this macro is used in order to *explicitly* test for identical behav
                     (loop :for v :below q :do
                       (setf (aref result (+ y u) (+ x v))
                             (* Aij (aref B u v))))))))))))))
+
+(defun make-vector (length &rest elts)
+  (let ((vec (qvm::make-lisp-cflonum-vector length)))
+    (loop :for i :from 0
+          :for elt :in elts
+          :do (setf (aref vec i) (cflonum elt))
+          :finally (return vec))))

--- a/tests/wavefunction-tests.lisp
+++ b/tests/wavefunction-tests.lisp
@@ -26,21 +26,21 @@
 
 (deftest test-wavefunction-qubits ()
   "Test that WAVEFUNCTION-QUBITS works."
-  (is (= 1 (qvm::wavefunction-qubits (qvm::make-vector 2))))
-  (is (= 2 (qvm::wavefunction-qubits (qvm::make-vector 4))))
-  (is (= 3 (qvm::wavefunction-qubits (qvm::make-vector 8))))
-  (is (= 4 (qvm::wavefunction-qubits (qvm::make-vector 16)))))
+  (is (= 1 (qvm::wavefunction-qubits (make-vector 2))))
+  (is (= 2 (qvm::wavefunction-qubits (make-vector 4))))
+  (is (= 3 (qvm::wavefunction-qubits (make-vector 8))))
+  (is (= 4 (qvm::wavefunction-qubits (make-vector 16)))))
 
 (deftest test-copy-wavefunction ()
   "Test that COPY-WAVEFUNCTION works."
-  (let ((wf1 (qvm::make-vector 1 1))
-        (wf2 (qvm::make-vector 2 1 2))
-        (wf4 (qvm::make-vector 4 1 2 3 4))
-        (wf8 (qvm::make-vector 8 1 2 3 4 5 6 7 8))
-        (d1 (qvm::make-vector 1))
-        (d2 (qvm::make-vector 2))
-        (d4 (qvm::make-vector 4))
-        (d8 (qvm::make-vector 8)))
+  (let ((wf1 (make-vector 1 1))
+        (wf2 (make-vector 2 1 2))
+        (wf4 (make-vector 4 1 2 3 4))
+        (wf8 (make-vector 8 1 2 3 4 5 6 7 8))
+        (d1 (make-vector 1))
+        (d2 (make-vector 2))
+        (d4 (make-vector 4))
+        (d8 (make-vector 8)))
     (macrolet ((test-each-combo (sources destinations)
                  `(progn
                     ;; Try each src first.


### PR DESCRIPTION
This adds an ALLOCATE-VECTOR and a host of different allocation modes.

This commit doesn't actually incorporate it into the actual API,
however, which will come in later commits.

TODO:

- [x] create allocator interface/protocol
- [x] add tests for the allocator interface
- [x] plug interface into `make-qvm`
- [x] plug interface into other QVM creation mechanisms (`noisy-qvm`, etc.)
- [x] change `qvm-app` to use new interface
- [x] allow better options in `qvm-app` to control allocation kind
- [x] write roadmap in new GitHub issue for persistent QVMs