### PR TITLE
add qualcs benchmark

### DIFF
--- a/app/src/benchmark-programs.lisp
+++ b/app/src/benchmark-programs.lisp
@@ -27,8 +27,12 @@
        (format t "MEASURE ~D ro[~D]~%" i i)))))
 
 ;;; Benchmark from https://github.com/qulacs/qulacs
+;;;
+;;; Note that the original benchmark as stated requires 100 shots. It
+;;; is not clear if the wavefunction can be sampled to do this, or
+;;; whether the program must be run 100 times..
 (defun qualcs-program (n &key (rx-layers 10))
-  "The qualcs benchmark, specified to be 10 layers of random RX rotations interleaved with 9 layers of neighboring CNOTs, followed by 100 shots.
+  "The qualcs benchmark, specified to be 10 layers of random RX rotations interleaved with 9 layers of neighboring CNOTs, followed by measurement of all qubits.
 
 We are assuming the CNOTs are dense on an even number of qubits."
   (assert (plusp rx-layers))

--- a/app/src/benchmark-programs.lisp
+++ b/app/src/benchmark-programs.lisp
@@ -27,17 +27,18 @@
        (format t "MEASURE ~D ro[~D]~%" i i)))))
 
 ;;; Benchmark from https://github.com/qulacs/qulacs
-(defun qualcs-program (n)
+(defun qualcs-program (n &key (rx-layers 10))
   "The qualcs benchmark, specified to be 10 layers of random RX rotations interleaved with 9 layers of neighboring CNOTs, followed by 100 shots.
 
 We are assuming the CNOTs are dense on an even number of qubits."
+  (assert (plusp rx-layers))
   (safely-parse-quil-string
    (with-output-to-string (*standard-output*)
      ;; Initial RX layer.
      (loop :for q :below n :do
        (format t "RX(~F) ~D~%" (random (* 2 pi)) q))
      ;; CNOT-RX layers.
-     (loop :repeat 9 :do
+     (loop :repeat (1- rx-layers) :do
        ;; CNOT's
        (loop :with qubits := (alexandria:shuffle (alexandria:iota n))
              :repeat (floor n 2)

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -9,7 +9,7 @@
 (defvar *entered-from-main* nil)
 (defvar *program-name* "qvm")
 
-(defparameter *benchmark-types* '("bell" "qft" "hadamard" #-forest-sdk "suite")
+(defparameter *benchmark-types* '("bell" "qft" "hadamard" "qualcs" #-forest-sdk "suite")
   "List of allowed benchmark names.")
 
 (defparameter *available-simulation-methods* '("pure-state" "full-density-matrix")

--- a/doc/man/qvm.1
+++ b/doc/man/qvm.1
@@ -70,7 +70,7 @@ Specify the number of qubits a program must contain before parallelization
 kicks in. The default value is unspecified.
 .IP "--benchmark-type <name>"
 (Benchmark Mode) Run the benchmark named <name>. Benchmarks include
-"bell", "qft", "hadamard".
+"bell", "qft", "hadamard", "qualcs".
 .IP "-h, --help"
 Show the help message.
 .IP "-v, --version"


### PR DESCRIPTION
Adds the benchmark proposed [here](https://github.com/qulacs/qulacs).

I think this is a great benchmark for improvements to compiled mode, mostly because it has huge layers of 1q/2q gates.