### PR TITLE
make MEASURE type safe

### DIFF
--- a/app/tests/suite.lisp
+++ b/app/tests/suite.lisp
@@ -70,7 +70,7 @@ I 2")
                   (qvm-app::perform-multishot-measure simulation-method processed-quil 3 qubits 1 relabeling))))
           (is (equalp results-1 results-2)))))))
 
-(deftest test-multishot-measure-more-qubits-bug ()
+(deftest test-multishot-measure-qubits-out-of-bounds ()
   "Test that we handle out-of-bounds measurements correctly, even with relabelings."
   ;; Version #1
   (multiple-value-bind (p relabeling) (qvm-app::process-quil

--- a/src/measurement.lisp
+++ b/src/measurement.lisp
@@ -70,6 +70,11 @@ EXCITED-PROBABILITY should be the probability that QUBIT measured to |1>, regard
   qvm)
 
 (defmethod measure ((qvm pure-state-qvm) q)
+  (check-type q nat-tuple-element)
+  (assert (< q (number-of-qubits qvm)) (qvm q)
+          "Trying to measure qubit ~D on a QVM with only ~D qubit~:P."
+          q
+          (number-of-qubits qvm))
   (let* ((r (random 1.0d0))
          (excited-probability (qubit-probability qvm q))
          (cbit (if (<= r excited-probability)

--- a/tests/measurement-tests.lisp
+++ b/tests/measurement-tests.lisp
@@ -183,3 +183,9 @@
                       (qvm:measure-all qvm)
                     (is (every #'= bits measured-bits))
                     (is (= 1 (qvm::nth-amplitude qvm i)))))))))
+
+(deftest test-out-of-bounds-measurement ()
+  "Test that measuring a qubit out-of-bounds is an error."
+  (signals error (qvm:measure (qvm:make-qvm 1) -1))
+  (signals error (qvm:measure (qvm:make-qvm 1) 1))
+  (not-signals error (qvm:measure (qvm:make-qvm 1) 0)))


### PR DESCRIPTION
`qvm:measure` was absolutely not type safe. It allowed very dangerous calls which led to failing tests in OOB memory accesses.

The `qvm:measure` generic function accepted any `q` which was blindly passed to `force-measurement`, which was optimized dangerously. This plugs that hole, but I wonder what else is lurking.