### PR TITLE
Don't start server if only -p is provided.

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -32,6 +32,7 @@
     (("server" #\S)
      :type boolean
      :optional t
+     :initial-value nil
      :documentation "start a QVM server")
 
     (("host")
@@ -474,7 +475,7 @@ Version ~A is available from downloads.rigetti.com/qcs-sdk/forest-sdk.dmg~%"
      (perform-benchmark benchmark-type benchmark))
 
     ;; Server mode.
-    ((or server port)
+    (server
      (when execute
        (format-log "Warning: Ignoring execute option: ~S" execute)
        (setf execute nil))

--- a/app/tests/suite.lisp
+++ b/app/tests/suite.lisp
@@ -162,3 +162,11 @@ Y 1"))))
                       ;; to a compatible size
                       (qvm-app::perform-expectation simulation-method state-prep ops 5))))
         (is (quil::double= 0.0 (first answer)))))))
+
+(deftest test-server-startup-behaviour ()
+  ;; Test that providing -p without -S does *not* start the server.
+  (is (typep (with-input-from-string (*standard-input* "H 0")
+               (quilc::%entry-point (list "quilc" "-p" "1000")))
+             'hash-table))
+  ;; TODO One day, some more checks that quilc behaves.
+  )


### PR DESCRIPTION
Or rather, *only* start server if `-S` is provided. Closes #77.