### PR TITLE
fix breakage due to feature/lifting in cl-quil

### DIFF
--- a/examples/qft.lisp
+++ b/examples/qft.lisp
@@ -16,7 +16,7 @@
               :for qe :in (reverse qubits)
               :collect (make-instance 'quil:gate-application
                                       :operator #.(quil:named-operator "SWAP")
-                                      :gate (quil:lookup-standard-gate "SWAP")
+                                      :name-resolution (quil:lookup-standard-gate "SWAP")
                                       :arguments (list (quil:qubit qs)
                                                        (quil:qubit qe)))))))
 
@@ -27,7 +27,7 @@
                (if (null qs)
                    (list (make-instance 'quil:gate-application
                                         :operator #. (quil:named-operator "H")
-                                        :gate (quil:lookup-standard-gate "H")
+                                        :name-resolution (quil:lookup-standard-gate "H")
                                         :arguments (list (quil:qubit q))))
                    (let ((cR nil))
                      (loop :with n := (1+ (length qs))
@@ -37,7 +37,7 @@
                            :do (push (make-instance
                                       'quil:gate-application
                                       :operator #.(quil:named-operator "CPHASE")
-                                      :gate (quil:lookup-standard-gate "CPHASE")
+                                      :name-resolution (quil:lookup-standard-gate "CPHASE")
                                       :parameters (list (quil:constant angle))
                                       :arguments (list (quil:qubit q)
                                                        (quil:qubit qi)))
@@ -47,7 +47,7 @@
                       cR
                       (list (make-instance 'quil:gate-application
                                            :operator #. (quil:named-operator "H")
-                                           :gate (quil:lookup-standard-gate "H")
+                                           :name-resolution (quil:lookup-standard-gate "H")
                                            :arguments (list (quil:qubit q))))))))))
     (make-instance 'quil:parsed-program
                    :gate-definitions nil

--- a/src/compile-gate.lisp
+++ b/src/compile-gate.lisp
@@ -329,15 +329,7 @@ If the gate can't be compiled, return (VALUES NIL NIL).")
 (defun pull-teeth-to-get-a-gate (gate-app)
   "Produce a valid, applicable gate from the application GATE-APPLICATION."
   (check-type gate-app quil:gate-application)
-  (if (quil::anonymous-gate-application-p gate-app)
-      (quil::gate-application-gate gate-app)
-      (if (slot-boundp gate-app 'quil::gate)
-          (quil::gate-application-gate gate-app)
-          (funcall
-           (quil::operator-description-gate-lifter
-            (quil:application-operator gate-app))
-           (quil:gate-definition-to-gate
-            (quil::gate-application-resolution gate-app))))))
+  (quil:gate-application-gate gate-app))
 
 (defmethod compile-instruction (qvm (isn quil:gate-application))
   ;; Reject compiling an operator with unknown parameters.

--- a/src/depolarizing-noise.lisp
+++ b/src/depolarizing-noise.lisp
@@ -48,9 +48,9 @@ It should be that PX + PY + PZ <= 1.
 "
   (check-type qubit unsigned-byte)
   (assert (<= (+ px py pz) 1))
-  (let ((X (lookup-gate qvm "X"))
-        (Y (lookup-gate qvm "Y"))
-        (Z (lookup-gate qvm "Z"))
+  (let ((X (quil:gate-definition-to-gate (quil:lookup-standard-gate "X")))
+        (Y (quil:gate-definition-to-gate (quil:lookup-standard-gate "Y")))
+        (Z (quil:gate-definition-to-gate (quil:lookup-standard-gate "Z")))
         (sum (+ px py pz)))
     (probabilistically sum
       (setf px (/ px sum)

--- a/src/noisy-qvm.lisp
+++ b/src/noisy-qvm.lisp
@@ -68,7 +68,9 @@ The arguments PX, PY and PZ can be interpreted as probabilities of a X, Y or Z e
            (loop :for sj :in '("X" "Y" "Z")
                  :for pj :in (list px py pz)
                  :collect (magicl:scale (sqrt pj)
-                                        (quil:gate-matrix (quil:lookup-standard-gate sj))))))
+                                        (quil:gate-matrix
+                                         (quil:gate-definition-to-gate
+                                          (quil:lookup-standard-gate sj)))))))
     (check-type psum (real 0 1))
     (when (< psum 1)
       (push (magicl:scale (sqrt (- 1.0 psum)) (magicl:make-identity-matrix 2)) scaled-paulis))
@@ -94,7 +96,9 @@ by GATE-NAME. The resulting gate is equivalent to I' * U, i.e., the ideal gate U
 a noisy identity gate I' as defined in MAKE-PAULI-NOISE-MAP.
 "
   (let ((kraus-ops (make-pauli-noise-map px py pz))
-        (u (quil:gate-matrix (quil:lookup-standard-gate gate-name))))
+        (u (quil:gate-matrix
+            (quil:gate-definition-to-gate
+             (quil:lookup-standard-gate gate-name)))))
     (mapcar (lambda (v) (magicl:multiply-complex-matrices v u)) kraus-ops)))
 
 (defun check-kraus-ops (kraus-ops)

--- a/src/transition.lisp
+++ b/src/transition.lisp
@@ -82,7 +82,10 @@ Return two values:
         (measure qvm q)
       ;; Conditionally do an X.
       (when (= 1 measured-bit)
-        (apply-gate (quil:lookup-standard-gate "X")
+        (apply-gate (load-time-value
+                     (quil:gate-definition-to-gate
+                      (quil:lookup-standard-gate "X"))
+                     t)
                     (amplitudes measured-qvm)
                     (nat-tuple q)))
       (values measured-qvm (1+ (pc measured-qvm))))))

--- a/tests/gate-tests.lisp
+++ b/tests/gate-tests.lisp
@@ -125,11 +125,11 @@
 "
   (let ((X0 (make-instance 'quil:gate-application
                            :operator #.(quil:named-operator "X")
-                           :gate (quil:lookup-standard-gate "X")
+                           :name-resolution (quil:lookup-standard-gate "X")
                            :arguments (list (quil:qubit 0))))
         (X1 (make-instance 'quil:gate-application
                            :operator #.(quil:named-operator "X")
-                           :gate (quil:lookup-standard-gate "X")
+                           :name-resolution (quil:lookup-standard-gate "X")
                            :arguments (list (quil:qubit 1))))
         (qft (qvm-examples:qft-circuit '(0 1))))
     (flet ((prepend (&rest apps)


### PR DESCRIPTION
This fixes some backwards incompat. changes from cl-quil.

These changes also cause a performance regression in the runtime of the QVM. Namely:

- For rotation gates, `sin`, `cos`, and `/` are computed 2x more often.
- For permutation gates like `CNOT`, it's no longer recognized that they're permutations, so the qvm runs them far more inefficiently.

The latter causes the bigger perf regression, and should be solved with @notmgsk's pending PR to quilc.