### PR TITLE
Provide --proxy, catch usocket errors, SDK check off by default

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -140,11 +140,15 @@
      :optional t
      :documentation "debug mode, specifically this causes the QVM to not automatically catch execution errors allowing interactive debugging via SWANK.")
 
-    #+forest-sdk
-    (("skip-version-check"
-      :type boolean
-      :initial-value nil
-      :documentation "Do not check for a new QVM version at launch."))
+    (("check-sdk-version")
+     :type boolean
+     :initial-value nil
+     :documentation "Check for a new SDK version at launch.")
+
+    (("proxy")
+     :type string
+     :initial-value nil
+     :documentation "Proxy to use when checking for an SDK update.")
 
     (("quiet")
      :type boolean
@@ -350,7 +354,8 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
                           shared
                           simulation-method
                           #-forest-sdk debug
-                          #+forest-sdk skip-version-check
+                          check-sdk-version
+                          proxy
                           quiet
                           log-level)
 
@@ -376,14 +381,14 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
   (when check-libraries
     (check-libraries))
 
-  #+forest-sdk
-  (unless skip-version-check
+  (when check-sdk-version
     (multiple-value-bind (available-p version)
-        (sdk-update-available-p +QVM-VERSION+)
+        (sdk-update-available-p +QVM-VERSION+ :proxy proxy)
       (when available-p
         (format t "An update is available to the SDK. You have version ~A. ~
 Version ~A is available from https://www.rigetti.com/forest~%"
-                +QVM-VERSION+ version))))
+                +QVM-VERSION+ version))
+      (uiop:quit (if (and available-p version) 0 1))))
 
   (when verbose
     (setf qvm:*transition-verbose* t))

--- a/app/src/qvm-app-version.lisp
+++ b/app/src/qvm-app-version.lisp
@@ -35,23 +35,36 @@
     :documentation "The git hash of the QVM repo.")
   )
 
-(defun latest-sdk-version ()
-  "Get the latest SDK quilc version, or NIL if unavailable."
+(defun latest-sdk-version (&key (proxy nil))
+  "Get the latest SDK qvm version, or NIL if unavailable."
   (handler-case
       (let* ((s (drakma:http-request "http://downloads.rigetti.com/qcs-sdk/version"
-                                     :want-stream t))
+                                     :want-stream t
+                                     :proxy proxy))
              (p (yason:parse s)))
         (multiple-value-bind (version success)
             (gethash "qvm" p)
           (when success
             version)))
-    (usocket:ns-host-not-found-error (condition)
+    (usocket:ns-error (condition)
       (declare (ignore condition))
+      (cl-syslog:rfc-log (*logger* :warning "Encountered a name resolution error when fetching latest SDK version. (~A)" condition)
+        (:msgid "LOG0001"))
+      nil)
+    (usocket:socket-error (condition)
+      (declare (ignore condition))
+      (cl-syslog:rfc-log (*logger* :warning "Encountered a socket error when fetching latest SDK version. (~A)" condition)
+        (:msgid "LOG0001"))
+      nil)
+    (sb-bsd-sockets:socket-error (condition)
+      (declare (ignore condition))
+      (cl-syslog:rfc-log (*logger* :warning "Encountered a socket error when fetching latest SDK version. (~A)" condition)
+        (:msgid "LOG0001"))
       nil)))
 
-(defun sdk-update-available-p (current-version)
+(defun sdk-update-available-p (current-version &key (proxy nil))
   "Test whether the current QVM version is the latest SDK
 version. Second value returned indicates the latest version."
-  (let ((latest (latest-sdk-version)))
-    (values (and latest (not (string= latest current-version)))
+  (let ((latest (latest-sdk-version :proxy proxy)))
+    (values (and latest (uiop:version< current-version latest))
             latest)))


### PR DESCRIPTION
The changes here are three:

1. Catch USOCKET:NS-ERROR and USOCKET:SOCKET-ERROR when checking for an SDK update. Originally we caught USOCKET:NS-HOST-NOT-FOUND-ERROR, but this allowed other related errors through, causing the app to crash.
2. Provide --proxy to be used by quilc::latest-sdk-version and those behind network restrictions. This one makes me slightly uncomfortable, since it may be confused with providing a proxy for the server itself.
3. Replace the off-by-default --skip-version-check with the off-by-default --check-sdk-version. Network issues may cause the app to crash or be slow while waiting for the update check to finish; IMO this should be opt-in. Also, this option now causes the program to exit (with an appropriate return code).

Closes #86 and #88.
