### PR TITLE
Add system-index.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+*~
 *.fasl
 build-output.log
 docker_qvm.tar
 qvm
 quilbasic
+system-index.txt
 .idea/


### PR DESCRIPTION
system-index.txt is generated by quicklisp
