### PR TITLE
[wip] Allow changing the number of threads in thread pool

### DIFF
--- a/qvm-tests.asd
+++ b/qvm-tests.asd
@@ -33,4 +33,5 @@
                (:file "noisy-qvm-tests")
                (:file "density-qvm-tests")
                (:file "stress-tests")
-               (:file "path-simulate-tests")))
+               (:file "path-simulate-tests")
+               (:file "parallel-tests")))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -167,8 +167,7 @@ The result will be a list of cons cells representing half-open intervals (on the
   #-unix
   1)
 
-(let ((prepared? nil)
-      (workers-allotted nil))
+(let ((prepared? nil))
   (defun prepare-for-parallelization (&optional num-workers)
     "Prepare for parallelization.
 
@@ -188,14 +187,13 @@ NOTE: This must be done before computations can be done.
              cores is ~D."
             num-workers
             (count-logical-cores))
-    (when (and prepared? (integerp num-workers) (not (= workers-allotted num-workers))) ; force creating a new kernel
+    (when (and prepared? (integerp num-workers) (not (= (lparallel:kernel-worker-count) num-workers))) ; force creating a new kernel
       (lparallel:end-kernel :wait t)
       (setf prepared? nil))
     (unless prepared?
       (let ((num-workers (or num-workers (count-logical-cores))))
         (setf lparallel:*kernel*
               (lparallel:make-kernel num-workers :name "QVM Worker"))
-        (setf workers-allotted num-workers)
         (setf prepared? t)))
 
     (values)))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -168,7 +168,7 @@ The result will be a list of cons cells representing half-open intervals (on the
   1)
 
 (defun prepare-for-parallelization (&optional num-workers)
-  "Prepare for parallelization.
+  "Create a worker pool if none exists or if NUM-WORKERS has changed.
 
 If NUM-WORKERS is not provided, the number of workers will be set to the number of logical cores of your machine. ~
 This function does nothing if NUM-WORKERS workers have already been created. ~

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -167,9 +167,8 @@ The result will be a list of cons cells representing half-open intervals (on the
   #-unix
   1)
 
-(let ((prepared? nil))
-  (defun prepare-for-parallelization (&optional num-workers)
-    "Prepare for parallelization.
+(defun prepare-for-parallelization (&optional num-workers)
+  "Prepare for parallelization.
 
 If NUM-WORKERS is not provided, the number of workers will be set to the number of logical cores of your machine. ~
 This function does nothing if NUM-WORKERS workers have already been created. ~
@@ -177,26 +176,25 @@ If NUM-WORKERS is provided it should be less than the number of logical cores of
 
 NOTE: This must be done before computations can be done.
 "
-    (check-type num-workers (or null (integer 1)))
-    (assert (or (null num-workers) (<= num-workers (count-logical-cores)))
-            ()
-            "The number of workers for parallelization exceeds the ~
+  (check-type num-workers (or null (integer 1)))
+  (assert (or (null num-workers) (<= num-workers (count-logical-cores)))
+          ()
+          "The number of workers for parallelization exceeds the ~
              number of cores. This could be because ~
              #'QVM:PREPARE-FOR-PARALLELIZATION was called too early. ~
              The number of workers is ~D and the number of logical ~
              cores is ~D."
-            num-workers
-            (count-logical-cores))
-    (when (and prepared? (integerp num-workers) (not (= (lparallel:kernel-worker-count) num-workers))) ; force creating a new kernel
-      (lparallel:end-kernel :wait t)
-      (setf prepared? nil))
-    (unless prepared?
-      (let ((num-workers (or num-workers (count-logical-cores))))
-        (setf lparallel:*kernel*
-              (lparallel:make-kernel num-workers :name "QVM Worker"))
-        (setf prepared? t)))
+          num-workers
+          (count-logical-cores))
+  (when (and lparallel:*kernel*
+             (integerp num-workers)
+             (not (= (lparallel:kernel-worker-count) num-workers))) ; force creating a new kernel
+    (lparallel:end-kernel :wait t))
+  (unless lparallel:*kernel*
+    (setf lparallel:*kernel*
+          (lparallel:make-kernel (or num-workers (count-logical-cores)) :name "QVM Worker")))
 
-    (values)))
+  (values))
 
 ;;; Bit Injection/Ejection
 

--- a/tests/parallel-tests.lisp
+++ b/tests/parallel-tests.lisp
@@ -1,0 +1,24 @@
+;;;; tests/parallel-tests.lisp
+;;;;
+;;;; Author: John Lapeyre
+
+(in-package #:qvm-tests)
+
+(deftest test-changing-number-of-workers ()
+  "Test that preparing for parallelization is idempotent only if the number of workers does not change.
+
+More precisely, idempotent in side-effects. The function PREPARE-FOR-PARALLELIZATION is called only for side effects."
+  (qvm:prepare-for-parallelization 1)
+  (if (< (count-logical-cores) 2)
+      (is lparallel:*kernel*) ; For one core, we only check that the thread pool is created.
+      (let* ((save-kernel-1 lparallel:*kernel*)
+             (num-workers-1 (lparallel:kernel-worker-count))
+             (save-kernel-1-again (progn (qvm:prepare-for-parallelization 1)
+                                        lparallel:*kernel*))
+             (save-kernel-2 (progn (qvm:prepare-for-parallelization 2)
+                                   lparallel:*kernel*))
+             (num-workers-2 (lparallel:kernel-worker-count)))
+        (is (= num-workers-1 1)) ; Was one worker actually created ?
+        (is (= num-workers-2 2)) ; Were two workers actually created ?
+        (is (eq save-kernel-1 save-kernel-1-again)) ; Was the second preparation a no-op ?
+        (is (not (eq save-kernel-1 save-kernel-2)))))) ; Did the third preparation create a new worker pool ?


### PR DESCRIPTION
This PR is a step towards making tuning the number of threads more flexible.

This commit improves the behavior of prepare-for-parallelization.

The following are corrected:

* The message given by the assert call may be inaccurate when calling
  prepare-for-parallelization twice with different arguments.
* The doc string refers to the function by the wrong name.

Furthermore, calling prepare-for-parallelization once and then
calling it again with a different argument now changes the number
of threads. More precisely, the existing thread pool is freed and
a new one is created only if the number of threads requested differs
between the two calls.

The existing test suite passes. But this PR needs tests.