### PR TITLE
optionally parallelize multishot

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -24,6 +24,12 @@
      :type string
      :initial-value "native"
      :documentation "select where wavefunctions get allocated: \"native\" (default) for native allocation, \"foreign\" for C-compatible allocation")
+
+    (("single-user")
+     :type boolean
+     :optional t
+     :documentation "enable if the server is intended to service just one request at a time")
+
     (("execute" #\e)
      :type boolean
      :optional t
@@ -335,6 +341,7 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
                           check-libraries
                           verbose
                           default-allocation
+                          single-user
                           execute
                           help
                           memory-limit
@@ -501,7 +508,16 @@ Version ~A is available from https://www.rigetti.com/forest~%"
          (start-shm-info-server shm-name (length **persistent-wavefunction**)))
 
        (format-log "Created persistent memory for ~D qubits" qubits))
-     ;; Start the server
+     ;; Start the server.
+     ;;
+     ;; As we learned from quilc, making a global state mutation isn't
+     ;; good for reproducible tests. This should really be bound as a
+     ;; special, or threaded through. But since QVM-APP hasn't gone
+     ;; through the transformation yet of changing these global
+     ;; mutations to bindings, we just follow suit here.
+     (setf *single-user-mode* single-user)
+     (when *single-user-mode*
+       (format-log "Starting the QVM server in single-user mode"))
      (start-server-app host port))
 
     ;; Batch mode.

--- a/app/src/globals.lisp
+++ b/app/src/globals.lisp
@@ -11,6 +11,8 @@
 (defvar *safe-include-directory* nil)
 (defvar *app* nil)
 (defvar *debug* nil)
+(defvar *single-user-mode* nil
+  "Is the qvm-app configured for just a single user at a time? (Using this doesn't affect correctness, just performance.)")
 
 (global-vars:define-global-var **persistent-wavefunction** nil)
 (global-vars:define-global-var **persistent-wavefunction-finalizer** (constantly nil))

--- a/app/src/utilities.lisp
+++ b/app/src/utilities.lisp
@@ -102,6 +102,11 @@
               (tbnl:session-remote-addr tbnl:*session*)
               (tbnl:session-id tbnl:*session*))))
 
+(global-vars:define-global-var **log-lock** (bt:make-lock "Log Lock"))
+(defmacro with-locked-log (() &body body)
+  `(bt:with-lock-held (**log-lock**)
+     ,@body))
+
 (defmacro format-log (level-or-fmt-string &rest fmt-string-or-args)
   "Send a message to syslog. If the first argument LEVEL-OR-FMT-STRING is a
 keyword it is assumed to be a non-default log level (:debug), otherwise it is a control
@@ -111,16 +116,18 @@ string followed by optional args (as in FORMAT)."
     ;; time.
     (cl-syslog:get-priority level-or-fmt-string))
   (if (keywordp level-or-fmt-string)
-      `(cl-syslog:format-log
-        *logger*
-        ',level-or-fmt-string
-        "~A~@?"
-        (session-info)
-        ,@fmt-string-or-args)
-      `(cl-syslog:format-log
-        *logger*
-        ':debug
-        "~A~@?"
-        (session-info)
-        ,level-or-fmt-string
-        ,@fmt-string-or-args)))
+      `(with-locked-log ()
+         (cl-syslog:format-log
+          *logger*
+          ',level-or-fmt-string
+          "~A~@?"
+          (session-info)
+          ,@fmt-string-or-args))
+      `(with-locked-log ()
+         (cl-syslog:format-log
+          *logger*
+          ':debug
+          "~A~@?"
+          (session-info)
+          ,level-or-fmt-string
+          ,@fmt-string-or-args))))

--- a/doc/man/qvm.1
+++ b/doc/man/qvm.1
@@ -133,6 +133,9 @@ Perform a benchmark on <qubits> number of qubits (default is
 .IP "--benchmark-type <type>"
 The type of benchmark to run. Available options are "bell" (default),
 "qft", "hadamard", "qualcs", or "suite" (non-SDK).
+.IP "--single-user"
+If the QVM server is intended to service only one request at a time,
+this option may make processing the requests more efficient.
 
 .SH SHARED MEMORY MODE
 Shared memory mode is enabled by "--shared" and allows for


### PR DESCRIPTION
This fixes #108.

This adds a command line option `--single-user` which tells the QVM it can expect to address one request at a time. If a multishot experiment is done, and the number of shots exceeds 1000, then it will be parallelized.

Initial benchmarks (interpreted mode):

1. GHZ on 8 qubits, readout qubit 0, 20k shots: 3.7s (no parallel), 1.0s (parallel) [3.7x improvement]
2. GHZ on 18 qubits, readout qubit 0, 1k shots: 145.5s (no parallel), 41.3s (parallel) [3.5x improvement]

These are promising results and are probably useful in practice.

I think there's some TODO work on this PR still:


- [ ] What should the limit until parallelization occurs be? How should it be calculated?
- [ ] Is there a better way to indicate that the multishot programs can be treated statelessly from shot-to-shot? Any better way to indicate this to the user?
- [ ] How should it be communicated that more threads = more memory consumption? We spin up N QVMs for N workers.