### PR TITLE
Remove SLIME-MULTIPROCESSING from lisp-setup.md

### DIFF
--- a/doc/lisp-setup.md
+++ b/doc/lisp-setup.md
@@ -145,8 +145,7 @@ your `.emacs` file. This will make everything good.
                slime-indentation))
 
 (setq slime-net-coding-system 'utf-8-unix
-      slime-truncate-lines nil
-      slime-multiprocessing t)
+      slime-truncate-lines nil)
 
 (setq lisp-lambda-list-keyword-parameter-alignment t
       lisp-lambda-list-keyword-alignment t)


### PR DESCRIPTION
This parrot is no more!

https://github.com/slime/slime/commit/7d17bb1e5881f1d3ca11ba25af60cd64896c2ee6