### PR TITLE
add baseline benchmark, remove computing it by default

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -10,7 +10,7 @@
 (defvar *entered-from-main* nil)
 (defvar *program-name* "qvm")
 
-(defparameter *benchmark-types* '("bell" "qft" "hadamard" "qualcs" #-forest-sdk "suite")
+(defparameter *benchmark-types* '("bell" "qft" "hadamard" "qualcs" "baseline" #-forest-sdk "suite")
   "List of allowed benchmark names.")
 
 (defparameter *available-simulation-methods* '("pure-state" "full-density-matrix")

--- a/doc/man/qvm.1
+++ b/doc/man/qvm.1
@@ -81,7 +81,7 @@ Specify the number of qubits a program must contain before parallelization
 kicks in. The default value is unspecified.
 .IP "--benchmark-type <name>"
 (Benchmark Mode) Run the benchmark named <name>. Benchmarks include
-"bell", "qft", "hadamard", "qualcs".
+"bell", "qft", "hadamard", "qualcs", "baseline".
 .IP "-h, --help"
 Show the help message.
 .IP "-v, --version"


### PR DESCRIPTION
allows `--benchmark-type baseline`