### PR TITLE
Qubit subsystems

### DIFF
--- a/qvm-tests.asd
+++ b/qvm-tests.asd
@@ -25,6 +25,7 @@
                (:file "linear-algebra-tests")
                (:file "classical-memory-tests")
                (:file "wavefunction-tests")
+               (:file "subsystem-tests")
                (:file "qvm-tests")
                (:file "measurement-tests")
                (:file "gate-tests")

--- a/qvm.asd
+++ b/qvm.asd
@@ -60,6 +60,7 @@
                (:file "classical-memory")
                (:file "classical-memory-mixin")
                (:file "wavefunction")
+               (:file "subsystem")
                (:file "qvm")
                (:file "compile-gate")
                (:file "apply-gate")

--- a/src/linear-algebra.lisp
+++ b/src/linear-algebra.lisp
@@ -27,14 +27,14 @@
 (defun make-matrix (size &rest elements)
   "Make a SIZE x SIZE complex matrix whose elements are ELEMENTS. Each of ELEMENTS must be able to be coerced into a CFLONUM."
   (declare (dynamic-extent elements))
-  (let ((matrix (make-array (list size size)
-                            :element-type 'cflonum
-                            :initial-element (cflonum 0))))
-    (loop :for i :from 0
-          :for raw-element :in elements
-          :for element :of-type cflonum := (cflonum raw-element)
-          :do (setf (row-major-aref matrix i) element)
-          :finally (return matrix))))
+  (loop :with matrix := (make-array (list size size)
+                                    :element-type 'cflonum
+                                    :initial-element (cflonum 0))
+        :for i :from 0
+        :for raw-element :in elements
+        :for element :of-type cflonum := (cflonum raw-element)
+        :do (setf (row-major-aref matrix i) element)
+        :finally (return matrix)))
 
 (defun magicl-matrix-to-quantum-operator (m)
   "Convert a MAGICL matrix M to a QUANTUM-OPERATOR."

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -47,6 +47,8 @@
    #:quantum-operator                   ; TYPE
    #:quantum-state                      ; TYPE
    #:octets-required-for-qubits         ; FUNCTION
+   #:make-matrix                        ; FUNCTION
+   #:magicl-matrix-to-quantum-operator  ; FUNCTION
    )
 
   ;; qam.lisp
@@ -86,6 +88,7 @@
 
   ;; wavefunction.lisp
   (:export
+   #:wf                                 ; FUNCTION
    #:copy-wavefunction                  ; FUNCTION
    #:probability                        ; FUNCTION
    #:apply-operator                     ; FUNCTION

--- a/src/subsystem.lisp
+++ b/src/subsystem.lisp
@@ -1,0 +1,179 @@
+;;;; lazy-entangle.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:qvm)
+
+;;;; This file contains code to efficiently work with qubit subsystems
+;;;; (uncorrelated states).
+
+(defstruct (subsystem (:predicate subsystemp))
+  "Representation of the state of a subsystem of qubits."
+  ;; STATE is a quantum operator expressed in the standard computation
+  ;; basis of QUBITS. For example, if QUBITS is #b101, then the basis
+  ;; of STATE is:
+  ;;
+  ;;     |0⟩₂ ⊗ |0⟩₀
+  ;;     |0⟩₂ ⊗ |1⟩₀
+  ;;     |1⟩₂ ⊗ |0⟩₀
+  ;;     |1⟩₂ ⊗ |1⟩₀
+  (state  (wf 1) :type quantum-state :read-only t)
+  ;; QUBITS is a bit-set. That is, the Nth bit of QUBITS is 1 if this
+  ;; subsystem contains qubit N.
+  (qubits 0      :type unsigned-byte :read-only t))
+
+(defun make-subsystem-on-qubits (&rest qubits)
+  "Make a subsystem (in the zero-state) for the qubits QUBITS.
+
+Note: Duplicate qubits are ignored."
+  (declare (dynamic-extent qubits))
+  (loop :with qubit-set := 0
+        :for q :in qubits
+        :do (setf qubit-set (dpb 1 (byte 1 q) qubit-set))
+        :finally (return
+                   (make-subsystem :qubits qubit-set
+                                   :state (let ((state (make-lisp-cflonum-vector
+                                                        (expt 2 (logcount qubit-set)))))
+                                            (setf (aref state 0) (cflonum 1))
+                                            state)))))
+
+(defun subsystem-num-qubits (ss)
+  "How many qubits does the subsystem SS represent?"
+  (logcount (subsystem-qubits ss)))
+
+(defmethod print-object ((ss subsystem) stream)
+  (print-unreadable-object (ss stream :type t :identity nil)
+    (let ((qubits (subsystem-qubits ss)))
+      (format stream "~Dq" (subsystem-num-qubits ss))
+      (when (plusp qubits)
+        (format stream ":")
+        (loop :for i :below (integer-length (subsystem-qubits ss))
+              :when (logbitp i qubits)
+                :do (format stream " ~D" i))))))
+
+(defun subsystem-contains-qubit-p (ss qubit)
+  "Does the subsystem SS contain the qubits QUBIT?"
+  (logbitp qubit (subsystem-qubits ss)))
+
+(defun subsystem-contains-qubits-p (ss qubit-set)
+  "Does the subsystem SS contain the qubits designated by the bit-set QUBIT-SET?"
+  (zerop (logandc1 (subsystem-qubits ss) qubit-set)))
+
+(defun subsystem-physical-to-logical-qubit (ss phys-qubit)
+  "What logical qubit number does the physical qubit PHYS-QUBIT have in the subsystem SS?
+
+(The  \"logical qubit\" is the relative position of the qubit in the system.)"
+  (and (subsystem-contains-qubit-p ss phys-qubit)
+       (logcount (ldb (byte phys-qubit 0) (subsystem-qubits ss)))))
+
+(defun %collapse-integer-by-mask (integer mask)
+  "Let INTEGER and MASK be integers of the same bit-length. Remove the bits of INTEGER that correspond to the zeros of MASK."
+  (loop :with collapsed := 0
+        :with j := 0
+        :for i :below (integer-length mask)
+        :when (logbitp i mask)
+          :do (setf collapsed (dpb (ldb (byte 1 i) integer)
+                                   (byte 1 j) collapsed))
+              (incf j)
+        :finally (return collapsed)))
+
+;;; Maybe a future TODO:
+;;;
+;;;    - Allow JOIN-SUBSYSTEMS to take any number of args.
+;;;
+;;;    - Allow EJECT-QUBIT-FROM-SUBSYSTEM to take many qubits.
+
+(defun join-subsystems (ss1 ss2)
+  "Join two (disjoint) qubit subsystems SS1 and SS2 into a larger qubit subsystem."
+  (let* ((q1 (subsystem-qubits ss1))
+         (q2 (subsystem-qubits ss2))
+         (new-qubits (logior q1 q2))
+         (collapsed-q1 (%collapse-integer-by-mask q1 new-qubits))
+         (collapsed-q2 (%collapse-integer-by-mask q2 new-qubits)))
+    (unless (zerop (logand q1 q2))
+      (error "The subsystems can't be joined because they share qubits."))
+    (let* ((new-state-size (expt 2 (logcount new-qubits)))
+           (new-state (make-lisp-cflonum-vector new-state-size)))
+      (loop :with ss1-state := (subsystem-state ss1)
+            :with ss2-state := (subsystem-state ss2)
+            :for addr :below new-state-size
+            :do (setf (aref new-state addr)
+                      (* (aref ss1-state (%collapse-integer-by-mask addr collapsed-q1))
+                         (aref ss2-state (%collapse-integer-by-mask addr collapsed-q2)))))
+      (make-subsystem :qubits new-qubits
+                      :state new-state))))
+
+(defun eject-qubit-from-subsystem (ss qubit)
+  "Eject the qubit QUBIT from the subsystem SS. Return two values:
+
+    1. A subsystem with the qubit factored out. (If the qubit is not a part of the system, it is assumed to be in the zero state.)
+
+    2. The state of the factored out qubit."
+  (cond
+    ;; The qubit isn't even a part of the subsystem you dummy!
+    ((not (subsystem-contains-qubit-p ss qubit))
+     (values ss (wf 1 0)))
+    ;; We only have one qubit. Skip the rigamarole.
+    ((= 1 (subsystem-num-qubits ss))
+     (values (make-subsystem :qubits 0 :state (wf 1))
+             (subsystem-state ss)))
+    ;; The general case.
+    (t
+     ;; We are factoring ψ = ψ′ ⊗ ϕ, where ψ′ is the larger qubit
+     ;; system returned by this function, and ϕ is the qubit state of
+     ;; QUBIT.
+     (let* ((ψ  (subsystem-state ss))
+            (ψ′ (make-lisp-cflonum-vector (half (length ψ))))
+            (ϕ  (make-lisp-cflonum-vector 2)))
+       (declare (type quantum-state ψ ψ′ ϕ))
+       ;; Calculate the ancilla state ϕ, where the full state ψ assumed to look
+       ;; like
+       ;;
+       ;;    a0 b0 |00⟩ + a0 b1 |01⟩ + ... + a0 bn |0n⟩ + a1 b0 |10⟩ + ...
+       ;;
+       ;; This loop seeks the largest ai bj, hence largest ai and bj
+       ;; individually, which tamps down on numerical error incurred
+       ;; from dividing by near-zero.
+       (loop :with abs := 0.0d0
+             :for j :below (length ψ)
+             :for ψⱼ := (aref ψ j)
+             :for αⱼ := (abs ψⱼ)
+             :when (< abs αⱼ)
+               :do (let* ((i  (ldb (byte 1 qubit) j))
+                          (Xi (- 1 i))
+                          (Xj (logxor j (ash 1 qubit))))
+                     (declare (type bit i Xi))
+                     (setf abs         αⱼ
+                           (aref ϕ i)  ψⱼ
+                           (aref ϕ Xi) (aref ψ Xj))))
+
+       ;; ϕ looks like a0 bj |0⟩ + a1 bj |1⟩ for some j, so we normalize out bj.
+       (setf ϕ (normalize-wavefunction ϕ))
+       ;; Calculate the factorized state. Still assuming ψ as above,
+       ;; we pick the larger al of a0, a1 ...
+       ;;
+       ;; LARGER-INDEX should be clearly interpreted as
+       ;; INDEX-OF-LARGER-AMPLITUDE, but that's too long to write.
+       (let* ((larger-index (boolean-bit (<= (abs (aref ϕ 0))
+                                             (abs (aref ϕ 1)))))
+              (rescale (/ (aref ϕ larger-index)))   ; Guaranteed non-zero.
+              (ratio (* rescale (aref ϕ (- 1 larger-index)))))
+         (declare (type cflonum rescale ratio))
+         (dotimes (j (length ψ))
+           (cond
+             ;; ... then examine al b0 |l0⟩ + ... al bn |ln⟩, and scale out al.
+             ((= larger-index (ldb (byte 1 qubit) j))
+              (setf (aref ψ′ (eject-bit j qubit)) (* rescale (aref ψ j))))
+             ;; Also, we should be able to infer the value of
+             ;;
+             ;;     a(1-l) bj |(1-j)j⟩
+             ;;
+             ;; in ψ from a(1-l) / al * al bj. If this ever fails, the
+             ;; ancilla is actually entangled.
+             ((not (quil::double= (aref ψ j) (* ratio (aref ψ (logxor j (ash 1 qubit))))))
+              (cerror "Continue anyway."
+                      "Tried to disentagle qubit ~D that is actually entangled."
+                      qubit)))))
+       (values (make-subsystem :qubits (dpb 0 (byte 1 qubit) (subsystem-qubits ss))
+                               :state ψ′)
+               ϕ)))))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -64,6 +64,11 @@ ELT will be bound to the element itself."
              :do (progn
                    ,@body)))))
 
+(declaim (inline nat-tuple-position))
+(defun nat-tuple-position (nt elt)
+  "In what position is ELT in the nat-tuple NT?"
+  (position elt nt))
+
 (defun nat-tuple-complement (n nt)
   "Compute the complement of the nat tuple NT in a universe of (0 1 2 ... N-1)."
   (let* ((nt-len (nat-tuple-cardinality nt))
@@ -352,3 +357,8 @@ whether the number of iterations N exceeds the threshold set by
                      :do (lparallel:submit-task ,ch #',worker-function ,start ,end))
                (loop :repeat (length ,ranges)
                      :sum (the flonum (lparallel:receive-result ,ch)) :of-type flonum)))))))
+
+(defun power-of-two-p (n)
+  "Is N equal to some non-negative integer power of two?"
+  (check-type n unsigned-byte)
+  (and (plusp n) (zerop (logand n (1- n)))))

--- a/src/wavefunction.lisp
+++ b/src/wavefunction.lisp
@@ -348,14 +348,22 @@ If the length/norm of WAVEFUNCTION is known, it can be passed as the LENGTH para
     (declare (type (flonum 0) inv-norm))
 
     ;; Normalize the wavefunction
-    (if (<= *qubits-required-for-parallelization* num-qubits)
-        (lparallel:pdotimes (i (length wavefunction))
-          (setf (aref wavefunction i) (* inv-norm (aref wavefunction i))))
-        (dotimes (i (length wavefunction))
-          (setf (aref wavefunction i) (* inv-norm (aref wavefunction i)))))
+    (pdotimes (i (length wavefunction) wavefunction)
+      (setf (aref wavefunction i) (* inv-norm (aref wavefunction i))))))
 
-    ;; Return the wavefunction.
-    wavefunction))
+;;; This is intended to be a shorthand for testing.
+(declaim (ftype (function (number &rest number) quantum-state) wf))
+(defun wf (elt &rest elts)
+  "Construct a wavefunction from the elements (ELT . ELTS)."
+  (declare (dynamic-extent elts))
+  (let ((n (1+ (length elts))))
+    (assert (power-of-two-p n) () "The number of elements supplied to WF must be a power of two.")
+    (let ((psi (make-lisp-cflonum-vector n)))
+      (setf (aref psi 0) (cflonum elt))
+      (loop :for i :from 1
+            :for elt :in elts
+            :do (setf (aref psi i) (cflonum elt))
+            :finally (return (normalize-wavefunction psi))))))
 
 (declaim (ftype (function (t) (simple-array flonum (*)))
                 cumulative-distribution-function))

--- a/tests/subsystem-tests.lisp
+++ b/tests/subsystem-tests.lisp
@@ -1,0 +1,114 @@
+;;;; subsystem-tests.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:qvm-tests)
+
+(deftest test-subsystem-sundries ()
+  (let ((ss0 (qvm::make-subsystem-on-qubits))
+        (ss1 (qvm::make-subsystem-on-qubits 0))
+        (ss2 (qvm::make-subsystem-on-qubits 0 2))
+        (ss3 (qvm::make-subsystem-on-qubits 0 2 4))
+        (ss3- (qvm::make-subsystem-on-qubits 0 1 1 2)))
+    (is (and (= 0 (qvm::subsystem-num-qubits ss0))
+             (= 1 (qvm::subsystem-num-qubits ss1))
+             (= 2 (qvm::subsystem-num-qubits ss2))
+             (= 3 (qvm::subsystem-num-qubits ss3))
+             (= 3 (qvm::subsystem-num-qubits ss3-))))
+    (is (= 8 (length (qvm::subsystem-state ss3-))))
+    (is (and (qvm::subsystem-contains-qubit-p ss3 0)
+             (qvm::subsystem-contains-qubit-p ss3 2)
+             (qvm::subsystem-contains-qubit-p ss3 4)))
+    (is (not (or (qvm::subsystem-contains-qubit-p ss3 1)
+                 (qvm::subsystem-contains-qubit-p ss3 3)
+                 (qvm::subsystem-contains-qubit-p ss3 5))))
+    (is (and (qvm::subsystem-contains-qubits-p ss3 (qvm::subsystem-qubits ss3))
+             (qvm::subsystem-contains-qubits-p ss3 (qvm::subsystem-qubits ss2))
+             (qvm::subsystem-contains-qubits-p ss3 (qvm::subsystem-qubits ss1))
+             (qvm::subsystem-contains-qubits-p ss3 (qvm::subsystem-qubits ss0))))
+    (is (not (qvm::subsystem-contains-qubits-p ss3 (qvm::subsystem-qubits ss3-))))
+    (is (and (= 0 (qvm::subsystem-physical-to-logical-qubit ss3 0))
+             (= 1 (qvm::subsystem-physical-to-logical-qubit ss3 2))
+             (= 2 (qvm::subsystem-physical-to-logical-qubit ss3 4))))))
+
+(deftest test-join-subsystems ()
+  (let ((ss001 (qvm::make-subsystem-on-qubits 0))
+        (ss010 (qvm::make-subsystem-on-qubits 1))
+        (ss100 (qvm::make-subsystem-on-qubits 2)))
+    (is (every #'cflonum=
+               (qvm::subsystem-state (qvm::join-subsystems ss001 ss010))
+               (qvm::subsystem-state (qvm::join-subsystems ss010 ss100))))
+    (is (every #'cflonum=
+               (qvm::subsystem-state (qvm::join-subsystems ss010 ss100))
+               (qvm::subsystem-state (qvm::join-subsystems ss100 ss001))))
+    (is (every #'cflonum=
+               (qvm:wf 0 1 0 0)
+               (qvm::subsystem-state
+                (qvm::join-subsystems (qvm::make-subsystem :qubits #b01
+                                                           :state (qvm:wf 0 1))
+                                      (qvm::make-subsystem :qubits #b100
+                                                           :state (qvm:wf 1 0))))))
+    (let ((superposition (qvm:wf (/ (sqrt 2)) (/ (sqrt 2)))))
+      (is (every #'cflonum=
+                 (qvm:wf 0.5 0.5 0.5 0.5)
+                 (qvm::subsystem-state
+                  (qvm::join-subsystems (qvm::make-subsystem :qubits #b01
+                                                             :state superposition)
+                                        (qvm::make-subsystem :qubits #b10
+                                                             :state superposition)))))
+      (is (every #'cflonum=
+                 (apply #'qvm:wf (make-list 16 :initial-element 0.25))
+                 (qvm::subsystem-state
+                  (qvm::join-subsystems
+                   (qvm::join-subsystems (qvm::make-subsystem :qubits #b0001
+                                                              :state superposition)
+                                         (qvm::make-subsystem :qubits #b0100
+                                                              :state superposition))
+                   (qvm::join-subsystems (qvm::make-subsystem :qubits #b0010
+                                                              :state superposition)
+                                         (qvm::make-subsystem :qubits #b1000
+                                                              :state superposition)))))))))
+
+(defun phase= (a b)
+  (flet ((same-or-zero-p (items)
+           (loop :with model-item := nil
+                 :for item :in items
+                 :if (and (null model-item)
+                          (not (zerop item)))
+                   :do (setf model-item item)
+                 :else
+                   :do (unless (double-float= item model-item)
+                         (return-from same-or-zero-p nil)))
+           ;; If we got here, we win!
+           t))
+    (same-or-zero-p (map 'list (lambda (x y)
+                                 (if (cflonum= 0 y)
+                                     0.0d0
+                                     (phase (/ x y))))
+                         a b))))
+
+(deftest test-eject-qubit-from-subsystem ()
+  (let* ((ss010 (qvm::make-subsystem :qubits #b010
+                                     :state (qvm:wf (/ (sqrt 2)) (/ (sqrt 2)))))
+         (ss101 (qvm::make-subsystem :qubits #b101
+                                     :state (qvm::randomize-wavefunction (qvm:wf 1 0 0 0))))
+         (ss111 (qvm::join-subsystems ss010 ss101))
+         (ss-spook (qvm::make-subsystem :qubits #b11
+                                        :state (qvm:wf (/ (sqrt 2)) 0 0 (/ (sqrt 2))))))
+    ;; Trivial ejections
+    (multiple-value-bind (new-state ejected-state) (qvm::eject-qubit-from-subsystem ss010 31337)
+      (is (eq new-state ss010))
+      (is (every #'cflonum= ejected-state (qvm:wf 1 0)))
+      (is (= #b010 (qvm::subsystem-qubits new-state))))
+    (multiple-value-bind (new-state ejected-state) (qvm::eject-qubit-from-subsystem ss010 1)
+      (is (zerop (qvm::subsystem-qubits new-state)))
+      (is (every #'cflonum= ejected-state (qvm::subsystem-state ss010))))
+
+    ;; Bad ejection
+    (signals error (qvm::eject-qubit-from-subsystem ss-spook 0))
+
+    ;; Non-trivial ejection
+    (multiple-value-bind (new-state ejected-state) (qvm::eject-qubit-from-subsystem ss111 1)
+      (is (phase= (qvm::subsystem-state ss101)
+                  (qvm::subsystem-state new-state)))
+      (is (phase= ejected-state (qvm::subsystem-state ss010))))))


### PR DESCRIPTION
This PR introduces a new basic data type: `SUBSYSTEM`. This is similar to ecp's asocial qvm stuff; this is intended to be the foundation to supporting disconnected qubit systems without hacking it on the current QVM.

Eventually, the QVM's state—`amplitudes`—will instead use a collection (possibly 1) of these.