### PR TITLE
Add intrinsics feature to app-ng tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ test-app:
 		 --eval '(ql:quickload :qvm-app-tests)' \
 		 --eval '(asdf:test-system :qvm-app)'
 
+test-app-ng: QVM_FEATURES=qvm-intrinsics
 test-app-ng:
 	$(QUICKLISP) \
 		--eval '(ql:quickload :qvm-app-ng-tests)' \


### PR DESCRIPTION
This fixes the app-ng tests which are failing when run with `make test`.