### PR TITLE
Add persistent qvm + async jobs api endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,22 @@ test-app-ng:
 		--eval '(ql:quickload :qvm-app-ng-tests)' \
 		--eval '(asdf:test-system :qvm-app-ng)'
 
+# Re-run the full QVM-APP-NG-TESTS suite using the generic bordeaux-threads implementation of the
+# SAFETY-HASH package. Run the test-app-ng target via a recursive make invocation here, rather than
+# specifying it as a prerequisite; otherwise, in a command line invocation like
+#
+#     make test-app-ng test-app-ng-with-generic-safety-hash
+#
+# Make will consider the test-app-ng goal to be up-to-date when test-app-ng-with-generic-safety-hash
+# runs. Run clean-cache before and after to ensure that this and subsequent builds aren't polluted
+# with stale FASLs. Since nuking the cache in this way is obnoxious, don't run these tests as a
+# prerequisite of the default "make test" target.
+test-app-ng-with-generic-safety-hash: QVM_FEATURES=qvm-intrinsics qvm-app-ng-generic-safety-hash
+test-app-ng-with-generic-safety-hash:
+	$(MAKE) clean-cache
+	$(MAKE) QVM_FEATURES="$(QVM_FEATURES)" test-app-ng
+	$(MAKE) clean-cache
+
 test-ccl:
 	ccl --batch --eval '(ql:quickload :qvm)' --eval '(quit)'
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Heap space for QVM in MiB.
 QVM_WORKSPACE ?= 2048
+THIS_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 LISP_CACHE ?= `sbcl --noinform --non-interactive --eval '(princ asdf:*user-cache*)'`
+QVM_LISP_CACHE ?= $(LISP_CACHE)$(THIS_DIR)
 
 # QVM feature flags (in QVM_FEATURES)
 QVM_FEATURE_FLAGS=$(foreach feature,$(QVM_FEATURES),--eval '(pushnew :$(feature) *features*)')
@@ -157,14 +159,14 @@ test-app-ng:
 #     make test-app-ng test-app-ng-with-generic-safety-hash
 #
 # Make will consider the test-app-ng goal to be up-to-date when test-app-ng-with-generic-safety-hash
-# runs. Run clean-cache before and after to ensure that this and subsequent builds aren't polluted
-# with stale FASLs. Since nuking the cache in this way is obnoxious, don't run these tests as a
-# prerequisite of the default "make test" target.
+# runs. Run clean-qvm-cache before and after to ensure that this and subsequent builds aren't
+# polluted with stale FASLs. Since nuking the cache in this way is obnoxious, don't run these tests
+# as a prerequisite of the default "make test" target.
 test-app-ng-with-generic-safety-hash: QVM_FEATURES=qvm-intrinsics qvm-app-ng-generic-safety-hash
 test-app-ng-with-generic-safety-hash:
-	$(MAKE) clean-cache
+	$(MAKE) clean-qvm-cache
 	$(MAKE) QVM_FEATURES="$(QVM_FEATURES)" test-app-ng
-	$(MAKE) clean-cache
+	$(MAKE) clean-qvm-cache
 
 test-ccl:
 	ccl --batch --eval '(ql:quickload :qvm)' --eval '(quit)'
@@ -187,6 +189,12 @@ clean-cache:
 	$(QUICKLISP) \
              --eval "(ql:register-local-projects)"
 	rm -rf "$(LISP_CACHE)"
+
+clean-qvm-cache:
+	@echo "Deleting $(QVM_LISP_CACHE)"
+	$(QUICKLISP) \
+		--eval "(ql:register-local-projects)"
+	rm -rf $(QVM_LISP_CACHE)
 
 clean-quicklisp:
 	@echo "Cleaning up old projects in Quicklisp"

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ qvm: system-index.txt
 qvm-ng: system-index.txt
 	$(SBCL) $(FOREST_SDK_FEATURE) \
 		--eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
+		$(QVM_FEATURE_FLAGS) \
 		--load build-app-ng.lisp \
 		$(FOREST_SDK_OPTION)
 

--- a/app-ng/CrustyOldDockerfile
+++ b/app-ng/CrustyOldDockerfile
@@ -1,6 +1,6 @@
 # This is a version of the app-ng Dockerfile that is compatible with
-# crusty old versions of docker that do not support ARG directives or
-# COPY --from. Humph.
+# crusty old versions of docker (like the one installed on big-qvm)
+# that do not support ARG directives or COPY --from. Humph.
 
 FROM rigetti/quilc:1.11.1
 FROM rigetti/lisp:2019-07-11

--- a/app-ng/CrustyOldDockerfile
+++ b/app-ng/CrustyOldDockerfile
@@ -4,7 +4,7 @@
 
 FROM rigetti/quilc:1.15.1
 FROM rigetti/lisp:2019-11-30
-RUN git clone https://github.com/rigetti/quilc /src/quilc
+RUN git clone --branch v1.15.1 --depth=1 https://github.com/rigetti/quilc /src/quilc
 
 # build the qvm-ng app
 ADD . /src/qvm

--- a/app-ng/CrustyOldDockerfile
+++ b/app-ng/CrustyOldDockerfile
@@ -2,8 +2,8 @@
 # crusty old versions of docker (like the one installed on big-qvm)
 # that do not support ARG directives or COPY --from. Humph.
 
-FROM rigetti/quilc:1.11.1
-FROM rigetti/lisp:2019-07-11
+FROM rigetti/quilc:1.15.1
+FROM rigetti/lisp:2019-11-30
 RUN git clone https://github.com/rigetti/quilc /src/quilc
 
 # build the qvm-ng app

--- a/app-ng/Dockerfile
+++ b/app-ng/Dockerfile
@@ -1,7 +1,7 @@
 # TODO(appleby): This Dockerfile should eventually be merged with the toplevel Dockerfile.
 # specify the dependency versions (can be overriden with --build_arg)
-ARG quilc_version=1.11.1
-ARG quicklisp_version=2019-07-11
+ARG quilc_version=1.15.1
+ARG quicklisp_version=2019-11-30
 
 # use multi-stage builds to independently pull dependency versions
 FROM rigetti/quilc:$quilc_version as quilc

--- a/app-ng/src/entry-point.lisp
+++ b/app-ng/src/entry-point.lisp
@@ -74,13 +74,13 @@
     #|not reached|#))
 
 (defun show-help ()
-  (format *error-output* "Usage:~%")
-  (format *error-output* "    qvm-ng [<options>...]~%~%")
-  (format *error-output* "Options:~%")
-  (command-line-arguments:show-option-help *option-spec* :stream *error-output* :sort-names t))
+  (format t "Usage:~%")
+  (format t "    qvm-ng [<options>...]~%~%")
+  (format t "Options:~%")
+  (command-line-arguments:show-option-help *option-spec* :sort-names t))
 
 (defun show-version ()
-  (format *error-output* "~A [~A]~%" +QVM-VERSION+ +GIT-HASH+))
+  (format t "~A [~A]~%" +QVM-VERSION+ +GIT-HASH+))
 
 (defun show-welcome ()
   (format *error-output*

--- a/app-ng/src/entry-point.lisp
+++ b/app-ng/src/entry-point.lisp
@@ -83,17 +83,31 @@
   (format t "~A [~A]~%" +QVM-VERSION+ +GIT-HASH+))
 
 (defun show-welcome ()
-  (format *error-output*
-          "~&*****************************************~%~
-             * Welcome to the Rigetti QVM (Next Gen) *~%~
-             *****************************************~%~
-             Copyright (c) 2016-2019 Rigetti Computing.~2%~
-             (Configured with ~A MiB of workspace and ~D core~:P.)~2%"
+  (format *error-output* "~&~
+******************************************
+* Welcome to the Rigetti QVM (Next Gen.) *~%~
+******************************************~%~
+Copyright (c) 2016-2019 Rigetti Computing.~2%")
+  (format *error-output* "(Configured with ~A MiB of workspace and ~D worker~:P.)~%"
           #+sbcl
           (floor (sb-ext:dynamic-space-size) (expt 1024 2))
           #-sbcl
           "many many"
           (max 1 (qvm:count-logical-cores)))
+  (format *error-output* "(Gates parallelize at ~D qubit~:P.)~%"
+          qvm::*qubits-required-for-parallelization*)
+  (format *error-output* "(There are ~D kernel~:P and they are used with ~
+              up to ~D qubit~:P.)~%"
+          (length qvm::*available-kernels*)
+          (qvm::qubit-limit-for-using-serial-kernels))
+  (let ((qvm-features
+          (list                         ; List of features
+                #+qvm-intrinsics
+                "qvm-intrinsics"
+                #+(and qvm-intrinsics avx2)
+                "avx2")))
+    (format *error-output* "(Features enabled: ~{~a~^, ~})~2%"
+            (or qvm-features (list "none"))))
   nil)
 
 (defun run-initial-rpc-request (rpc-request)

--- a/app-ng/src/entry-point.lisp
+++ b/app-ng/src/entry-point.lisp
@@ -97,7 +97,8 @@
   nil)
 
 (defun run-initial-rpc-request (rpc-request)
-  (format t "~A~%" (dispatch-rpc-request (parse-json-or-lose rpc-request))))
+  (encode-response (dispatch-rpc-request (parse-json-or-lose rpc-request)))
+  (terpri))
 
 (defun generalized-boolean-to-exit-code (successp)
   (cond ((integerp successp) successp)

--- a/app-ng/src/entry-point.lisp
+++ b/app-ng/src/entry-point.lisp
@@ -97,10 +97,7 @@
   nil)
 
 (defun run-initial-rpc-request (rpc-request)
-  (let ((*request-json* (parse-json-or-lose rpc-request)))
-    (alexandria:if-let ((handler (lookup-rpc-handler-for-request *request-json*)))
-      (format t "~A~%" (funcall handler))
-      (error "No handler found for initial rpc request: ~S" rpc-request))))
+  (format t "~A~%" (dispatch-rpc-request (parse-json-or-lose rpc-request))))
 
 (defun generalized-boolean-to-exit-code (successp)
   (cond ((integerp successp) successp)

--- a/app-ng/src/entry-point.lisp
+++ b/app-ng/src/entry-point.lisp
@@ -1,6 +1,7 @@
 ;;;; app-ng/src/entry-point.lisp
 ;;;;
 ;;;; Author: Robert Smith
+;;;;         appleby
 
 (in-package #:qvm-app-ng)
 

--- a/app-ng/src/errors.lisp
+++ b/app-ng/src/errors.lisp
@@ -24,3 +24,34 @@
     "Error signalled when caller makes an invalid RPC request.")
   (def-rpc-error rpc-parameter-parse-error +http-bad-request+
     "Error signalled when a user provides a bad input parameter."))
+
+(define-condition user-input-error (simple-error) ()
+  (:documentation "Error that is signaled when validating user input fails."))
+
+(defun user-input-error (&optional format-control &rest format-arguments)
+  (error 'user-input-error :format-control format-control :format-arguments format-arguments))
+
+(defun rewrap-simple-error (original-error new-error-type)
+  "Maybe rewrap ORIGINAL-ERROR as a NEW-ERROR-TYPE.
+
+If both (TYPE-OF ORIGINAL-ERROR) and NEW-ERROR-TYPE are non-EQ subtypes of SIMPLE-ERROR, then return a new ERROR of type NEW-ERROR-TYPE copying over ORIGINAL-ERROR's :FORMAT-CONTROL and :FORMAT-ARGUMENTS.
+
+Otherwise, return ORIGINAL-ERROR."
+  (cond ((and (typep original-error 'simple-error)
+              (subtypep new-error-type 'simple-error)
+              (not (eq (type-of original-error) new-error-type)))
+         (make-condition new-error-type
+                         :format-control (simple-condition-format-control original-error)
+                         :format-arguments (simple-condition-format-arguments original-error)))
+        (t original-error)))
+
+(defun call-with-rewrapped-simple-errors (new-error-type function &rest args)
+  "APPLY FUNCTION to ARGS in an environment where SIMPLE-ERRORs are re-signaled as NEW-ERROR-TYPE.
+
+NEW-ERROR-TYPE should itself be a subtype of SIMPLE-ERROR."
+  (handler-case
+      (apply function args)
+    (simple-error (c)
+      ;; Alternatively, we could CHANGE-CLASS and UPDATE-INSTANCE-FOR-DIFFERENT-CLASS, but lets not
+      ;; get too crazy just yet. We're saving the Good Stuff for last.
+      (error (rewrap-simple-error c new-error-type)))))

--- a/app-ng/src/errors.lisp
+++ b/app-ng/src/errors.lisp
@@ -3,11 +3,11 @@
 (define-condition rpc-error (simple-error)
   ((http-status
     :initarg :http-status
-    :initform tbnl:+http-internal-server-error+
+    :initform +http-internal-server-error+
     :reader rpc-error-http-status))
   (:report (lambda (condition stream)
              (format stream "QVM RPC Error:~@[ ~A~]"
-                     (tbnl:reason-phrase (rpc-error-http-status condition)))
+                     (http-status-string (rpc-error-http-status condition)))
              (alexandria:when-let ((format-control (simple-condition-format-control condition)))
                (format stream "~&~?" format-control (simple-condition-format-arguments condition)))))
   (:documentation "Base error type for all RPC errors."))
@@ -20,7 +20,7 @@
                   (:documentation ,documentation))
                 (defun ,name (&optional format-control &rest format-arguments)
                   (error ',name :format-control format-control :format-arguments format-arguments)))))
-  (def-rpc-error rpc-bad-request-error tbnl:+http-bad-request+
+  (def-rpc-error rpc-bad-request-error +http-bad-request+
     "Error signalled when caller makes an invalid RPC request.")
-  (def-rpc-error rpc-parameter-parse-error tbnl:+http-bad-request+
+  (def-rpc-error rpc-parameter-parse-error +http-bad-request+
     "Error signalled when a user provides a bad input parameter."))

--- a/app-ng/src/errors.lisp
+++ b/app-ng/src/errors.lisp
@@ -1,3 +1,6 @@
+;;;; app-ng/src/errors.lisp
+;;;;
+;;;; Author: appleby
 (in-package #:qvm-app-ng)
 
 (define-condition rpc-error (simple-error)

--- a/app-ng/src/globals.lisp
+++ b/app-ng/src/globals.lisp
@@ -1,6 +1,8 @@
 ;;;; app-ng/src/globals.lisp
 ;;;;
-;;;; Author: appleby
+;;;; Author: Nikolas Tezak
+;;;;         Robert Smith
+;;;;         appleby
 (in-package #:qvm-app-ng)
 
 ;; These are GLOBAL-VARS but act like constants, so name them like constants.

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -138,13 +138,14 @@ GATE-NOISE is an optional list of three FLOATs giving the probabilities of a Pau
 MEASUREMENT-NOISE is an optional list of three FLOATs giving the probabilities of an X, Y, or Z gate happening before a MEASURE.
 
 Return a JSON-RESPONSE object that contains a HASH-TABLE with a \"bytes\" key indicating the estimated number of bytes required."
-  (make-json-response (alexandria:plist-hash-table
-                       `("bytes" ,(memory-required-for-qvm simulation-method
-                                                           allocation-method
-                                                           num-qubits
-                                                           gate-noise
-                                                           measurement-noise))
-                       :test #'equal)))
+  (declare (ignore allocation-method))
+  (make-json-response
+   (alexandria:plist-hash-table
+    `("bytes" ,(octets-required-for-qvm
+                (simulation-method->qvm-type simulation-method
+                                             :pauli-noise-p (or gate-noise measurement-noise))
+                num-qubits))
+    :test #'equal)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;; PERSISTENT QVM HANDLERS ;;;;;;;;;;;;;;;;;;;;;;;

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -46,7 +46,7 @@ Signal an error if no handler is found."
 
   (defun make-parsed-binding (parameter-spec)
     (destructuring-bind (var parse-function) parameter-spec
-      `(,var (funcall (alexandria:ensure-function ,parse-function) ,var))))
+      `(,var (call-with-rewrapped-simple-errors 'rpc-parameter-parse-error ,parse-function ,var))))
 
   (defun valid-rpc-handler-lambda-list-p (lambda-list)
     (every (lambda (parameter-spec)

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -221,7 +221,7 @@ Return a JSON-RESPONSE that contains T on success."
                      (addresses #'parse-addresses))
   "Read from a persistent QVM's classical memory registers.
 
-DANGER! DANGER! DANGER! The affects of reading from classical memory while a persistent QVM is running are undefined. Although this restriction is not (currently) enforced, for safety you should only read from a QVM's memory when it is in the READY state or the WAITING state due to executing a WAIT instruction.
+DANGER! DANGER! DANGER! The effects of reading from classical memory while a persistent QVM is running are undefined. Although this restriction is not (currently) enforced, for safety you should only read from a QVM's memory when it is in the READY state or the WAITING state due to executing a WAIT instruction.
 
 QVM-TOKEN is a valid persistent QVM token returned by the CREATE-QVM RPC call.
 
@@ -237,7 +237,7 @@ Return a JSON-RESPONSE that contains a HASH-TABLE of the contents of the memory 
                      (memory-contents #'parse-memory-contents))
   "Write to the classical memory of a persistent QVM.
 
-DANGER! DANGER! DANGER! The affects of writing to classical memory while a persistent QVM is running are undefined. Although this restriction is not (currently) enforced, for safety you should only write to a QVM's memory when it is in the READY state or the WAITING state due to executing a WAIT instruction.
+DANGER! DANGER! DANGER! The effects of writing to classical memory while a persistent QVM is running are undefined. Although this restriction is not (currently) enforced, for safety you should only write to a QVM's memory when it is in the READY state or the WAITING state due to executing a WAIT instruction.
 
 QVM-TOKEN is a valid persistent QVM token returned by the CREATE-QVM RPC call.
 

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -197,7 +197,7 @@ QVM-TOKEN is a valid persistent QVM token returned by the CREATE-QVM RPC call."
 
 QVM-TOKEN is a valid persistent QVM token returned by the CREATE-QVM RPC call."
   (delete-persistent-qvm qvm-token)
-  (make-json-response (format nil "Deleted persistent QVM ~D" qvm-token)))
+  (make-json-response (format nil "Deleted persistent QVM ~A" qvm-token)))
 
 (define-rpc-handler (handle-resume-from-wait "resume") ((qvm-token #'parse-qvm-token))
   "Resume execution of a persistent QVM that is in the WAITING state.
@@ -330,7 +330,7 @@ JOB-TOKEN is a valid JOB token returned by the CREATE-JOB RPC call."
 
 JOB-TOKEN is a valid JOB token returned by the CREATE-JOB RPC call."
   (delete-jobbo job-token)
-  (make-json-response (format nil "Deleted async JOB ~D" job-token)))
+  (make-json-response (format nil "Deleted async JOB ~A" job-token)))
 
 (define-rpc-handler (handle-job-result "job-result") ((job-token #'parse-job-token))
   "Return a JSON-RESPONSE with result of the given async JOB.

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -286,23 +286,6 @@ Return a JSON-RESPONSE that contains a HASH-TABLE of the contents of the memory 
                            compiled-quil
                            addresses))))
 
-(define-rpc-handler (handle-run-program/async "run-program-async")
-                    ((qvm-token #'parse-qvm-token)
-                     (compiled-quil #'parse-quil-string))
-  "Run COMPILED-QUIL asynchronously on the persistent QVM given by QVM-TOKEN.
-
-QVM-TOKEN is a valid persistent QVM token returned by the CREATE-QVM RPC call.
-
-COMPILED-QUIL is a STRING containing a valid Quil program.
-
-Return a JSON-RESPONSE that contains a HASH-TABLE with a \"token\" key with the newly-created async JOB's unique ID token."
-  (make-json-response
-   (alexandria:plist-hash-table
-    (list "token" (run-jobbo (lambda ()
-                               (run-program-on-persistent-qvm qvm-token compiled-quil))))
-    :test #'equal)
-   :status +http-accepted+))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;; ASYNC JOB HANDLERS ;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -300,7 +300,7 @@ SUB-REQUEST is a valid json object that indicates what RPC request should be run
      \"allocation-method\": \"native\",
      \"num-qubits\": 10,
      \"compiled-quil\": \"X 0\",
-     \"addresses\": {\"ro\": t}
+     \"addresses\": {\"ro\": true}
     }
 
 It is an error to attempt to nest \"create-job\" requests by specifying \"create-job\" as the \"type\" field of SUB-REQUEST.

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -112,7 +112,7 @@ Alternatively, the handler function can be called from lisp like so
   ;; text/html rather than application/json for backwards compatibility with previous QVM-APP API.
   (make-text-response (string-right-trim
                        '(#\Newline)
-                       (with-output-to-string (*error-output*)
+                       (with-output-to-string (*standard-output*)
                          (show-version)))))
 
 (define-rpc-handler (handle-qvm-memory-estimate "qvm-memory-estimate")

--- a/app-ng/src/handlers.lisp
+++ b/app-ng/src/handlers.lisp
@@ -325,9 +325,6 @@ It is an error to attempt to nest \"create-job\" requests by specifying \"create
 JOB-TOKEN is a valid JOB token returned by the CREATE-JOB RPC call.
 
 Return a JSON-RESPONSE that contains a HASH-TABLE with a \"token\" key with the newly-created JOB's unique ID token."
-  ;; TODO(appleby): should we attempt to LOOKUP-RPC-HANDLER-FOR-REQUEST here as a sanity check and
-  ;; early warning? Seems like an edge-case that's not worth special-casing.
-
   ;; TODO(appleby): should we whitelist rather than blacklist "asyncable" methods? Currently, we
   ;; allow creating a job for any RPC call other than create-job. Probably the only really useful
   ;; calls to run async are ones that perform computation (currently only run-program), although

--- a/app-ng/src/http-status.lisp
+++ b/app-ng/src/http-status.lisp
@@ -18,6 +18,8 @@
                   ,@(alexandria:ensure-list tbnl-documentation)))))
 
   (define-tbnl-derived-constant +http-ok+)
+  (define-tbnl-derived-constant +http-created+)
+  (define-tbnl-derived-constant +http-accepted+)
   (define-tbnl-derived-constant +http-bad-request+)
   (define-tbnl-derived-constant +http-internal-server-error+))
 

--- a/app-ng/src/http-status.lisp
+++ b/app-ng/src/http-status.lisp
@@ -1,0 +1,27 @@
+;;;; app-ng/src/http-status.lisp
+;;;;
+;;;; author: appleby
+;;;;
+;;;; This file provides a wafer-thin abstraction over HUNCHENTOOT's http-status response codes.
+;;;; More importantly, it also makes me feel warm-and-fuzzy for making an attempt to remain
+;;;; http-server-backend agnostic.
+(in-package #:qvm-app-ng)
+
+(deftype http-status () '(integer 100 599))
+
+(macrolet ((define-tbnl-derived-constant (status-symbol)
+             (check-type status-symbol symbol)
+             (let* ((tbnl-symbol (find-symbol (symbol-name status-symbol) 'tbnl))
+                    (tbnl-documentation (documentation tbnl-symbol 'variable)))
+               (assert (not (null tbnl-symbol)))
+               `(defconstant ,status-symbol ,tbnl-symbol
+                  ,@(alexandria:ensure-list tbnl-documentation)))))
+
+  (define-tbnl-derived-constant +http-ok+)
+  (define-tbnl-derived-constant +http-bad-request+)
+  (define-tbnl-derived-constant +http-internal-server-error+))
+
+(defun http-status-string (http-status)
+  "Return a human-readable status string for HTTP-STATUS."
+  (check-type http-status http-status)
+  (tbnl:reason-phrase http-status))

--- a/app-ng/src/job.lisp
+++ b/app-ng/src/job.lisp
@@ -1,0 +1,150 @@
+(in-package #:qvm-app-ng)
+
+(adt:defdata job-status
+  job-status-fresh
+  job-status-running
+  job-status-killed
+  (job-status-finished t)
+  (job-status-error condition))
+
+(defstruct (job (:constructor %make-job (work-function)))
+  "A job permits a given function to be run in a threaded (and thread-safe) environment."
+  (lock (bt:make-lock) :type bt:lock :read-only t)
+  ;; The job is ``performed'' by calling this function, where setting
+  ;; of job status and handling of errors is accounted for. A lock
+  ;; should be held by the caller when calling this function.
+  (work-function nil :type function :read-only t)
+  (thread nil :type (or null bt:thread))
+  (status job-status-fresh :type job-status))
+
+(defun job-status-name (job)
+  (adt:match job-status (job-status job)
+    (job-status-fresh "fresh")
+    (job-status-running "running")
+    (job-status-killed "killed")
+    ((job-status-finished _) "finished")
+    ((job-status-error _) "error")))
+
+(define-condition job-error (error)
+  ((job :initarg :job :reader job-error-job)
+   (message :initarg :message :reader job-error-msg))
+  (:report (lambda (c s)
+             (write-string (job-error-msg c) s)))
+  (:documentation "Error signaled because of job mismanagement."))
+
+(defmacro with-job-lock ((job &key (wait t)) &body body)
+  "Evaluate BODY with the LOCK acquired for the duration of BODY. If WAIT is T, block until the lock is available."
+  (alexandria:once-only (job wait)
+    `(when (bt:acquire-lock (job-lock ,job) ,wait)
+       (unwind-protect
+            (progn ,@body)
+         (bt:release-lock (job-lock ,job))))))
+
+(defmethod print-object ((job job) stream)
+  (print-unreadable-object (job stream :type nil :identity t)
+    (format stream "QVM Job (~A)" (job-status-name job))))
+
+;; The %x-unsafe variants below do not acquire a lock.
+
+(defun %job-running-p-unsafe (job)
+  (adt:match job-status (job-status job)
+    (job-status-running t)
+    (_ nil)))
+
+(defun job-running-p (job)
+  "Is the JOB in the RUNNING state."
+  (with-job-lock (job)
+    (%job-running-p-unsafe job)))
+
+(defun %job-killed-p-unsafe (job)
+  (adt:match job-status (job-status job)
+    (job-status-killed t)
+    (_ nil)))
+
+(defun job-killed-p (job)
+  "Is the JOB in the KILLED state?"
+  (with-job-lock (job)
+    (%job-killed-p-unsafe job)))
+
+(defun %job-finished-p-unsafe (job)
+  (adt:match job-status (job-status job)
+    ((job-status-finished _) t)
+    (_ nil)))
+
+(defun job-finished-p (job)
+  "Is the JOB in the FINISHED state?"
+  (with-job-lock (job)
+    (%job-finished-p-unsafe job)))
+
+(defun make-job (fn)
+  "Make a JOB object which will, under JOB-START, run FN in a thread.
+
+The returned JOB can be repeatedly started if the JOB-STATUS is FRESH.
+
+Note: Only interact with the job after acquiring the lock (or alternatively by using WITH-JOB-LOCK)."
+  (%make-job (lambda (job)
+               (adt:match job-status (job-status job)
+                 (job-status-fresh
+                  (setf (job-thread job)
+                        (bt:make-thread
+                         (lambda ()
+                           (let ((result 
+                                   (handler-case
+                                       (job-status-finished (funcall fn))
+                                     (error (c)
+                                       (job-status-error c)))))
+                             (with-job-lock (job)
+                               (setf (job-status job) result))))))
+                  (setf (job-status job) job-status-running))
+                 (_ (error 'job-error :job job :message "Job cannot be started because it is not fresh."))))))
+
+(defmacro define-job-action (action (job) &body body)
+  "Define a function ACTION taking a single argument JOB, that evaluates BODY while holding JOB's lock."
+  (multiple-value-bind (body decls docstr)
+      (alexandria:parse-body body :documentation t)
+    (declare (ignore decls))
+    `(defun ,action (,job)
+       ,docstr
+       (with-job-lock (,job)
+         ,@body))))
+
+;;; CUSTODIAL
+
+(define-job-action job-start (job)
+  "Start the JOB and return T. If JOB is already running, do nothing and return NIL."
+  (unless (%job-running-p-unsafe job)
+    (funcall (job-work-function job) job)
+    t))
+
+(defun force-kill-job (job)
+  "Forcefully kill JOB if running. Does not block and cannot be restarted."
+  (when (%job-running-p-unsafe job)
+    (bt:destroy-thread (job-thread job))
+    (setf (job-status job)
+          job-status-killed)))
+
+(define-job-action kill-job (job)
+  "Forcefully kill JOB if running as soon as lock is acquired. Job cannot be restarted."
+  (force-kill-job job))
+
+;;; sync/async
+
+(defun job-result (job)
+  "Inspect the result of JOB. If the job raised an error, the error will be signaled here. If JOB is in the running state, this will block."
+  (when (%job-running-p-unsafe job)
+    (bt:join-thread (job-thread job)))
+  (adt:match job-status (job-status job)
+    ((job-status-finished result) result)
+    ((job-status-error c) (error c))
+    (job-status-fresh (error 'job-error :job job :message "Job in fresh state, but expected a result."))
+    (job-status-killed (error 'job-error :job job :message "Job in killed state, but expected a result."))
+    (job-status-running (error 'job-error :job job :message "Inconsistent job state. Job should not be running at this point."))))
+
+(defun job-peek (job)
+  "Inspect the result of JOB without blocking. Returns (VALUES RESULT FINISHED) where RESULT is the job result if the job is in the finished state (i.e. FINISHED is T); if FINISHED is NIL, then a RESULT of NIL does *not* mean that is the true result of the most recent run of JOB."
+  (adt:match job-status (job-status job)
+    ((job-status-finished result)
+     (values result t))
+    (_
+     (values nil nil))))
+

--- a/app-ng/src/jobbo.lisp
+++ b/app-ng/src/jobbo.lisp
@@ -53,7 +53,11 @@ Return (VALUES TOKEN JOB) where TOKEN is the ID of the new job."
   (let* ((token (make-uuid-string))
          (job (make-job job-thunk)))
     (job-start job)
-    (safety-hash:insert-unique token job **jobs**)
+    (handler-case (safety-hash:insert-unique token job **jobs**)
+      (error (c)
+        ;; In the unlikely event of a token collision on insert, kill the job.
+        (kill-job job)
+        (error c)))
     (values token job)))
 
 (defun delete-jobbo (token)

--- a/app-ng/src/jobbo.lisp
+++ b/app-ng/src/jobbo.lisp
@@ -1,3 +1,9 @@
+;;;; app-ng/src/jobbo.lisp
+;;;;
+;;;; author: appleby
+;;;;
+;;;; This file will be renamed or else merged with job.lisp once that PR lands. I've stuck this code
+;;;; in a separate file for now to avoid merge conflicts.
 (in-package #:qvm-app-ng)
 
 (deftype job-token () 'string)

--- a/app-ng/src/jobbo.lisp
+++ b/app-ng/src/jobbo.lisp
@@ -34,7 +34,7 @@ Signals an error if the lookup of TOKEN fails."
 
 (defun reset-jobs-db ()
   "Reset the **JOBS** database."
-  (safety-hash:clrhash **JOBS**))
+  (safety-hash:clrhash **jobs**))
 
 (defun jobbo-info (token)
   "Return a HASH-TABLE of info about the state of the JOB corresponding to TOKEN."

--- a/app-ng/src/jobbo.lisp
+++ b/app-ng/src/jobbo.lisp
@@ -1,0 +1,64 @@
+(in-package #:qvm-app-ng)
+
+(deftype job-token () 'string)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun make-empty-jobbos-db ()
+    (safety-hash:make-safety-hash :test 'equal)))
+
+(global-vars:define-global-var **jobs** (make-empty-jobbos-db)
+  "The database of async JOBs. The keys are JOB-TOKENs and the values are JOBs.")
+
+(defmacro with-locked-jobbo ((job) token &body body)
+  "Execute BODY with JOB bound to the async JOB identified by TOKEN.
+
+BODY is executed with the JOB's lock held. No other guarantees are made about the state of the JOB.
+
+Signals an error if the lookup of TOKEN fails."
+  (check-type job symbol)
+  (alexandria:once-only (token)
+    `(let ((,job (%lookup-jobbo-or-lose ,token)))
+       (with-job-lock (,job)
+         ,@body))))
+
+(defun %lookup-jobbo-or-lose (token)
+  (handler-case (safety-hash:gethash-or-lose token **jobs**)
+    (error (c)
+      (error "Failed to find jobbo ~A~%~A" token c))))
+
+(defun reset-jobs-db ()
+  "Reset the **JOBS** database."
+  (safety-hash:clrhash **JOBS**))
+
+(defun jobbo-info (token)
+  "Return a HASH-TABLE of info about the state of the JOB corresponding to TOKEN."
+  (alexandria:plist-hash-table
+   (with-locked-jobbo (job) token
+     ;; TODO(appleby): Unify the naming of JOB-STATUS vs PERSISTENT-QVM-STATE. The STRING-UPCASE
+     ;; here is for symmetry with how persistent QVM state is reported. However, the job API calls
+     ;; this field "status" vs "state" for persistent QVMs.
+     (list "status" (string-upcase (job-status-name job))))
+   :test 'equal))
+
+(defun run-jobbo (job-thunk)
+  "Create and start a new async JOB running JOB-THUNK.
+
+Return (VALUES TOKEN JOB) where TOKEN is the ID of the new job."
+  (let* ((token (make-uuid-string))
+         (job (make-job job-thunk)))
+    (job-start job)
+    (safety-hash:insert-unique token job **jobs**)
+    (values token job)))
+
+(defun delete-jobbo (token)
+  "Delete the JOB corresponding to TOKEN."
+  (with-locked-jobbo (job) token
+    (force-kill-job job))
+  (safety-hash:remhash token **jobs**))
+
+(defun jobbo-result (token)
+  "Return the result of the JOB corresponding to TOKEN.
+
+This call will block with the job lock held until the job finishes."
+  (with-locked-jobbo (job) token
+    (job-result job)))

--- a/app-ng/src/jobbo.lisp
+++ b/app-ng/src/jobbo.lisp
@@ -2,8 +2,8 @@
 ;;;;
 ;;;; author: appleby
 ;;;;
-;;;; This file will be renamed or else merged with job.lisp once that PR lands. I've stuck this code
-;;;; in a separate file for now to avoid merge conflicts.
+;;;; TODO(appleby): This file will be renamed or else merged with job.lisp once that PR lands. I've
+;;;; stuck this code in a separate file for now to avoid merge conflicts.
 (in-package #:qvm-app-ng)
 
 (deftype job-token () 'string)

--- a/app-ng/src/logging.lisp
+++ b/app-ng/src/logging.lisp
@@ -1,3 +1,6 @@
+;;;; app-ng/src/logging.lisp
+;;;;
+;;;; author: appleby
 (in-package #:qvm-app-ng)
 
 (defvar *logger* (make-instance 'cl-syslog:rfc5424-logger

--- a/app-ng/src/make-qvm.lisp
+++ b/app-ng/src/make-qvm.lisp
@@ -1,6 +1,7 @@
 ;;;; src/make-qvm.lisp
 ;;;;
-;;;; Author: appleby
+;;;; Author: Nikolas Tezak
+;;;;         appleby
 
 (in-package #:qvm-app-ng)
 

--- a/app-ng/src/make-qvm.lisp
+++ b/app-ng/src/make-qvm.lisp
@@ -32,20 +32,18 @@
     ;; TODO(appleby): Perhaps we should add QVM:MAKE-DEPOLARIZING-QVM similar to QVM:MAKE-QVM and
     ;; QVM:MAKE-DENSITY-QVM. Along the way, it would be good to homogenize the interfaces and also
     ;; add QVM:MAKE-NOISY-QVM for completeness.
-    (multiple-value-bind (amplitudes finalizer)
-        (qvm:allocate-vector (make-requested-allocation-descriptor allocation-method
-                                                                   (expt 2 num-qubits)))
-      (qvm::bring-to-zero-state amplitudes)
-      (tg:finalize (make-instance 'qvm:depolarizing-qvm
-                                  :number-of-qubits num-qubits
-                                  :amplitudes amplitudes
-                                  :x (first gate-noise)
-                                  :y (second gate-noise)
-                                  :z (third gate-noise)
-                                  :measure-x (first measurement-noise)
-                                  :measure-y (second measurement-noise)
-                                  :measure-z (third measurement-noise))
-                   finalizer))))
+    (make-instance 'qvm:depolarizing-qvm
+                   :number-of-qubits num-qubits
+                   :state (qvm::make-pure-state num-qubits
+                                                :allocation (make-requested-allocation-descriptor
+                                                             allocation-method
+                                                             (expt 2 num-qubits)))
+                   :x (first gate-noise)
+                   :y (second gate-noise)
+                   :z (third gate-noise)
+                   :measure-x (first measurement-noise)
+                   :measure-y (second measurement-noise)
+                   :measure-z (third measurement-noise))))
 
 (defmethod make-requested-qvm ((simulation-method (eql 'full-density-matrix))
                                allocation-method

--- a/app-ng/src/make-qvm.lisp
+++ b/app-ng/src/make-qvm.lisp
@@ -29,9 +29,6 @@
                                measurement-noise)
   (let ((gate-noise (or gate-noise (load-time-value '(0.0 0.0 0.0))))
         (measurement-noise (or measurement-noise (load-time-value '(0.0 0.0 0.0)))))
-    ;; TODO(appleby): Perhaps we should add QVM:MAKE-DEPOLARIZING-QVM similar to QVM:MAKE-QVM and
-    ;; QVM:MAKE-DENSITY-QVM. Along the way, it would be good to homogenize the interfaces and also
-    ;; add QVM:MAKE-NOISY-QVM for completeness.
     (make-instance 'qvm:depolarizing-qvm
                    :number-of-qubits num-qubits
                    :state (qvm::make-pure-state num-qubits

--- a/app-ng/src/make-qvm.lisp
+++ b/app-ng/src/make-qvm.lisp
@@ -29,7 +29,7 @@
                                measurement-noise)
   (let ((gate-noise (or gate-noise (load-time-value '(0.0 0.0 0.0))))
         (measurement-noise (or measurement-noise (load-time-value '(0.0 0.0 0.0)))))
-    ;; TODO:(appleby) Perhaps we should add QVM:MAKE-DEPOLARIZING-QVM similar to QVM:MAKE-QVM and
+    ;; TODO(appleby): Perhaps we should add QVM:MAKE-DEPOLARIZING-QVM similar to QVM:MAKE-QVM and
     ;; QVM:MAKE-DENSITY-QVM. Along the way, it would be good to homogenize the interfaces and also
     ;; add QVM:MAKE-NOISY-QVM for completeness.
     (multiple-value-bind (amplitudes finalizer)

--- a/app-ng/src/package.lisp
+++ b/app-ng/src/package.lisp
@@ -3,4 +3,23 @@
 ;;;; Author: Robert Smith
 
 (defpackage #:qvm-app-ng
-  (:use #:cl #:qvm))
+  (:use #:cl #:qvm)
+
+  ;; job.lisp
+  (:export
+   #:job-status
+   #:job-status-fresh
+   #:job-status-running
+   #:job-status-interrupted
+   #:job-status-finished
+   #:job-status-error
+   #:job-status-name
+   #:make-job
+   #:job-running-p
+   #:job-interrupted-p
+   #:job-finished-p
+   #:job-start
+   #:kill-job
+   #:force-kill-job
+   #:job-result
+   #:job-peek))

--- a/app-ng/src/package.lisp
+++ b/app-ng/src/package.lisp
@@ -1,6 +1,8 @@
 ;;;; app-ng/src/package.lisp
 ;;;;
 ;;;; Author: Robert Smith
+;;;;         Mark Skilbeck
+;;;;         appleby
 
 (defpackage #:qvm-app-ng
   (:use #:cl #:qvm)

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -80,7 +80,7 @@
 
 This function only returns a new PERSISTENT-QVM object. External callers probably want ALLOCATE-PERSISTENT-QVM, instead.
 
-QVM is any QVM type (PURE-STATE-QVM, NOISY-QVM, etc).
+QVM is an instance of any QVM type (PURE-STATE-QVM, NOISY-QVM, etc).
 
 ALLOCATION-METHOD is one of +AVAILABLE-ALLOCATION-METHODS+. This only provided so that it can be recorded in the PERSISTENT-QVM's metadata.
 

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -32,11 +32,11 @@
   (safety-hash:hash-table-count **persistent-qvms**))
 
 (alexandria:define-constant +valid-pqvm-state-transitions+
-    '((ready    running           dying)
-      (running  ready    waiting  dying)
-      (waiting  resuming          dying)
-      (resuming running           dying)
-      (dying                      dying))
+    '((ready    . (running           dying))
+      (running  . (ready    waiting  dying))
+      (waiting  . (resuming          dying))
+      (resuming . (running           dying))
+      (dying    . (                  dying)))
   :test #'equal
   :documentation "An alist of valid state transitions for a PERSISTENT-QVM. The alist is keyed on the current state. The value for each key is list of states that can be transitioned to from the corresponding current state.")
 

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -70,7 +70,7 @@
                       (persistent-qvm-token pqvm)))))))
 
 (defun make-persistent-qvm-metadata (allocation-method)
-  "Make a hash-table suitable a new PERSISTENT-QVM's METADATA slot."
+  "Make a hash-table suitable for use as a new PERSISTENT-QVM's METADATA slot."
   (alexandria:plist-hash-table (list "allocation-method" (symbol-name allocation-method)
                                      "created" (iso-time))
                                :test 'equal))

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -18,18 +18,18 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun make-empty-persistent-qvms-db ()
-    (make-safety-hash :test 'equal)))
+    (safety-hash:make-safety-hash :test 'equal)))
 
 (global-vars:define-global-var **persistent-qvms** (make-empty-persistent-qvms-db)
   "The database of persistent QVMs. The keys are PERSISTENT-QVM-TOKENs and the values are PERSISTENT-QVMs.")
 
 (defun reset-persistent-qvms-db ()
   "Reset the **PERSISTENT-QVMS** database."
-  (safety-hash-clrhash **persistent-qvms**))
+  (safety-hash:clrhash **persistent-qvms**))
 
 (defun persistent-qvms-count ()
   "Return the number of PERSISTENT-QVMS currently allocated."
-  (safety-hash-table-count **persistent-qvms**))
+  (safety-hash:hash-table-count **persistent-qvms**))
 
 (alexandria:define-constant +valid-pqvm-state-transitions+
     '((ready    running           dying)
@@ -132,7 +132,7 @@ BODY is executed with the persistent QVM's lock held, and an error is signaled i
              (t ,@body)))))))
 
 (defun %lookup-persistent-qvm-or-lose (token)
-  (handler-case (safety-hash-gethash-or-lose token **persistent-qvms**)
+  (handler-case (safety-hash:gethash-or-lose token **persistent-qvms**)
     (error (c)
       (error "Failed to find persistent QVM ~A~%~A" token c))))
 
@@ -140,7 +140,7 @@ BODY is executed with the persistent QVM's lock held, and an error is signaled i
   "Delete the PERSISTENT-QVM indicated by TOKEN."
   (with-locked-pqvm (pqvm) token
     (%checked-transition-to-state-locked pqvm 'dying))
-  (safety-hash-remhash token **persistent-qvms**))
+  (safety-hash:remhash token **persistent-qvms**))
 
 (defun canonicalize-persistent-qvm-token (token)
   "Canonicalize the TOKEN string into the case expected by VALID-PERSISTENT-QVM-TOKEN-P."
@@ -164,7 +164,7 @@ QVM is a QVM object of any type (PURE-STATE-QVM, NOISY-QVM, etc.)
 ALLOCATION-METHOD should be one of the +AVAILABLE-ALLOCATION-METHODS+, and is used when creating the PERSISTENT-QVM's metadata."
   (let* ((token (make-persistent-qvm-token))
          (persistent-qvm (make-persistent-qvm qvm allocation-method token)))
-    (safety-hash-insert-unique token persistent-qvm **persistent-qvms**)
+    (safety-hash:insert-unique token persistent-qvm **persistent-qvms**)
     (values token persistent-qvm)))
 
 (defun persistent-qvm-info (token)

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -142,19 +142,9 @@ BODY is executed with the persistent QVM's lock held, and an error is signaled i
     (%checked-transition-to-state-locked pqvm 'dying))
   (safety-hash:remhash token **persistent-qvms**))
 
-(defun canonicalize-persistent-qvm-token (token)
-  "Canonicalize the TOKEN string into the case expected by VALID-PERSISTENT-QVM-TOKEN-P."
-  (canonicalize-uuid-string token))
-
 (defun make-persistent-qvm-token ()
   "Return a new persistent QVM token."
   (make-uuid-string))
-
-(defun valid-persistent-qvm-token-p (token)
-  "True if TOKEN is a valid string representation of a v4 UUID.
-
-Note that this function requires that any hexadecimal digits in TOKEN are lowercased."
-  (valid-uuid-string-p token))
 
 (defun allocate-persistent-qvm (qvm allocation-method)
   "Allocate a new PERSISTENT-QVM.

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -174,7 +174,7 @@ TOKEN is a PERSISTENT-QVM-TOKEN."
 
 The optional ADDRESSES are passed along to RUN-PROGRAM-ON-QVM and specify which memory register contents you want back.
 
-Returns the requested memory registers or signals an error if the given PERSISTENT-QVM is not in the READY state."
+Return the requested memory registers or signal an error if the given PERSISTENT-QVM is not in the READY state."
   (with-locked-pqvm (pqvm) token
     (case (persistent-qvm-state pqvm)
       (ready

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -21,7 +21,7 @@
     (make-hash-table :test 'equal)))
 
 (global-vars:define-global-var **persistent-qvms** (make-empty-persistent-qvms-db)
-  "The database of persistent QVMs. The keys are integers and the values are lists of (QVM LOCK METADATA) triples.")
+  "The database of persistent QVMs. The keys are PERSISTENT-QVM-TOKENs and the values are PERSISTENT-QVMs.")
 
 (global-vars:define-global-var **persistent-qvms-lock** (bt:make-lock "Persistent QVMs DB Lock"))
 

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -98,7 +98,7 @@ TOKEN is a PERSISTENT-QVM-TOKEN."
             (declare (ignore qvm))
             ;; LOCK must be held here or we're in trouble.
             (%checked-transition-to-state-locked pqvm 'waiting :from-state 'running)
-            ;; TODO:(appleby) possible to unwind from CONDITION-WAIT? Maybe UNWIND-PROTECT here.
+            ;; TODO(appleby): possible to unwind from CONDITION-WAIT? Maybe UNWIND-PROTECT here.
             (loop :while (persistent-qvm-state= 'waiting (persistent-qvm-state pqvm))
                   :do (bt:condition-wait cv lock)
                   :finally (unless (persistent-qvm-state= 'dying (persistent-qvm-state pqvm))

--- a/app-ng/src/persistent-qvm.lisp
+++ b/app-ng/src/persistent-qvm.lisp
@@ -1,4 +1,4 @@
-;;;; persistent-qvm.lisp
+;;;; app-ng/src/persistent-qvm.lisp
 ;;;;
 ;;;; Author: appleby
 

--- a/app-ng/src/qvm-app-ng-version.lisp
+++ b/app-ng/src/qvm-app-ng-version.lisp
@@ -1,4 +1,4 @@
-;;;; qvm-app-ng-version.lisp
+;;;; app-ng/src/qvm-app-ng-version.lisp
 ;;;;
 ;;;; Author: Robert Smith
 

--- a/app-ng/src/response.lisp
+++ b/app-ng/src/response.lisp
@@ -15,7 +15,7 @@ Slots:
 
     STATUS - an HTTP-STATUS for the response.
 
-    ENCODER - a FUNCTION of two arguments, the RESPONSE-DATA to encode and an optional stream on which to encode it. "
+    ENCODER - a FUNCTION of two arguments, the RESPONSE-DATA to encode and an optional stream on which to encode it."
   (data nil :read-only t)
   (status +http-ok+ :read-only t :type http-status)
   ;; Encoding could also be handled via generic function dispatch on the response type, but then you

--- a/app-ng/src/response.lisp
+++ b/app-ng/src/response.lisp
@@ -1,0 +1,71 @@
+;;;; app-ng/src/response.lisp
+;;;;
+;;;; author: appleby
+;;;;
+;;;; This file contains functions and data types for working with RPC responses.
+(in-package #:qvm-app-ng)
+
+(defstruct (response (:constructor nil))
+  "The type of a an RPC handler response.
+
+A RESPONSE cannot be constructed directly. Use one of the subtypes, JSON-RESPONSE or TEXT-RESPONSE.
+
+Slots:
+    DATA - The response data.
+
+    STATUS - an HTTP-STATUS for the response.
+
+    ENCODER - a FUNCTION of two arguments, the RESPONSE-DATA to encode and an optional stream on which to encode it. "
+  (data nil :read-only t)
+  (status +http-ok+ :read-only t :type http-status)
+  ;; Encoding could also be handled via generic function dispatch on the response type, but then you
+  ;; need one subtype per desired encoding scheme. We allow the caller to specify the encoder
+  ;; function as convenience, since there may be more that one way to map a lisp object to an
+  ;; encoded representation. For example, a caller can pass :ENCODER #'YASON:ENCODE-PLIST, to avoid
+  ;; having to first convert the plist to a HASH-TABLE for a JSON-RESPONSE. Likewise, for a
+  ;; TEXT-RESPONSE, one could pass #'WRITE-LINE to automatically get a newline appended, etc.
+  (encoder (error "RPC-RESPONSE :ENCODER is required") :read-only t :type function))
+
+(defstruct (json-response (:constructor %make-json-response)
+                          (:include response (encoder #'yason:encode)))
+  "The type of JSON-RESPONSE.
+
+See the documentation of RESPONSE for documentation on inherited slots.
+
+Inherited slot option overrides:
+    ENCODER - defaults to YASON:ENCODE.")
+
+(defstruct (text-response (:constructor %make-text-response)
+                          (:include response
+                           (encoder #'write-string)
+                           (data "" :type string)))
+  "The type of plain TEXT-RESPONSE.
+
+See the documentation of RESPONSE for documentation on inherited slots.
+
+Inherited slot option overrides:
+    ENCODER - defaults to WRITE-STRING.
+    DATA - must be of type STRING.")
+
+(defun make-json-response (data &rest args &key status encoder)
+  "Make a JSON-RESPONSE."
+  (declare (ignore status encoder))
+  (apply #'%make-json-response :data data args))
+
+(defun make-text-response (data &rest args &key status encoder)
+  "Make a TEXT-RESPONSE."
+  (declare (ignore status encoder))
+  (apply #'%make-text-response :data data args))
+
+(defun encode-response (response &optional (stream *standard-output*))
+  "Encode the RESPONSE on STREAM.
+
+This will call RESPONSE-ENCODER on the RESPONSE-DATA and STREAM."
+  (funcall (response-encoder response) (response-data response) stream))
+
+(defgeneric response-content-type (response)
+  (:documentation "Return an appropriate http content-type for RESPONSE.")
+  (:method ((response json-response))
+    (setf (tbnl:content-type*) "application/json; charset=utf-8"))
+  (:method ((response text-response))
+    (setf (tbnl:content-type*) "text/plain; charset=utf-8")))

--- a/app-ng/src/response.lisp
+++ b/app-ng/src/response.lisp
@@ -66,6 +66,6 @@ This will call RESPONSE-ENCODER on the RESPONSE-DATA and STREAM."
 (defgeneric response-content-type (response)
   (:documentation "Return an appropriate http content-type for RESPONSE.")
   (:method ((response json-response))
-    (setf (tbnl:content-type*) "application/json; charset=utf-8"))
+    "application/json; charset=utf-8")
   (:method ((response text-response))
-    (setf (tbnl:content-type*) "text/plain; charset=utf-8")))
+    "text/plain; charset=utf-8"))

--- a/app-ng/src/safety-hash.lisp
+++ b/app-ng/src/safety-hash.lisp
@@ -1,0 +1,111 @@
+;;;; safety-hash.lisp
+;;;;
+;;;; Author: appleby
+;;;;
+;;;;     Safety-hash!
+;;;;
+;;;;     Ah we can hash if we want to, we can leave your locks behind
+;;;;     Cause your threads don't hash and if they don't hash
+;;;;     Well they're are no threads of mine
+;;;;
+;;;; SAFETY-HASH implements a portable, thread-safe interface to basic CRUD operations for a
+;;;; globally-accessible hash-table-like object. SAFETY-HASHes are used in QVM-APP-NG to store
+;;;; PERSISTENT-QVMs and other objects which might persist between requests.
+;;;;
+;;;; The SAFETY-HASH implementation in this file is intended to be simple and portable (and probably
+;;;; slow). This portable implementation acquires and releases a non-recursive per-object lock
+;;;; around every operation. It depends on BORDEAUX-THREADS for the locking primitives.
+;;;;
+;;;; The SAFETY-HASH API sticks closely to the standard Common Lisp HASH-TABLE API, but doesn't
+;;;; attempt to be a drop-in replacement. Some of the standard functions that operate on HASH-TABLEs
+;;;; are missing, and other functions are included here which have no direct counterpart for
+;;;; standard HASH-TABLEs (e.g. SAFETY-HASH-INSERT-UNIQUE). Some of the standard HASH-TABLE
+;;;; functions are missing only because the rest of QVM-APP-NG has no use for them yet
+;;;; (e.g. HASH-TABLE-SIZE); others (MAPHASH, WITH-HASH-TABLE-ITERATOR) are missing partially
+;;;; because they are not yet needed, and partially because adding them would either mean switching
+;;;; to recursive locks, or else modifying the interfaces to do something different than their
+;;;; documented behavior in the standard. In such cases, the user always has an escape hatch in the
+;;;; form of the WITH-LOCKED-SAFETY-HASH macro, which locks the SAFETY-HASH and binds a reference to
+;;;; the underlying HASH-TABLE, which the caller can then modify as they please.
+;;;;
+;;;; For example, the caller is allowed to modify the current entry when iterating over a
+;;;; HASH-TABLE with MAPHASH, like so
+;;;;
+;;;;     (maphash (lambda (key value)
+;;;;                (setf (gethash key some-hash) (1+ value)))
+;;;;              some-hash)
+;;;;
+;;;; Translating the above into SAFETY-HASH-compatible API would produce something like
+;;;;
+;;;;     (safety-hash-maphash (lambda (key value)
+;;;;                            (setf (safety-hash-gethash key some-hash) (1+ value)))
+;;;;              some-hash)
+;;;;
+;;;; where the call to SAFETY-HASH-GETHASH would attempt to acquire the lock already held by
+;;;; SAFETY-HASH-MAPHASH. Switching to recursive locks here could work. For now, the recommend
+;;;; approach is to instead use WITH-LOCKED-SAFETY-HASH and operate on the underlying HASH-TABLE
+;;;; directly, like so:
+;;;;
+;;;;     (with-locked-safety-hash (hash-table) safety-hash
+;;;;       (maphash (lambda (key value)
+;;;;                  (setf (gethash key hash-table) (1+ value)))
+;;;;                hash-table)
+(in-package #:qvm-app-ng)
+
+(defstruct (safety-hash (:constructor %make-safety-hash))
+  (lock  (error "Must provide LOCK")  :read-only t)
+  (table (error "Must provide TABLE") :read-only t))
+
+(defun call-with-locked-safety-hash (safety-hash function)
+  (bt:with-lock-held ((safety-hash-lock safety-hash))
+    (funcall function (safety-hash-table safety-hash))))
+
+#+#:warning-extreme-danger-will-robinson-use-only-in-case-of-testing
+(defun call-with-locked-safety-hash (safety-hash function)
+  (funcall function (safety-hash-table safety-hash)))
+
+(defmacro with-locked-safety-hash ((hash-table) safety-hash &body body)
+  (check-type hash-table symbol)
+  `(call-with-locked-safety-hash ,safety-hash (lambda (hash-table) ,@body)))
+
+
+;;; Standard HASH-TABLE API replacements.
+
+(defun make-safety-hash (&rest make-hash-table-args)
+  (%make-safety-hash :lock (bt:make-lock) :table (apply #'make-hash-table make-hash-table-args)))
+
+(defun safety-hash-clrhash (safety-hash)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (clrhash hash-table)))
+
+(defun safety-hash-gethash (key safety-hash &optional default)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (gethash key hash-table default)))
+
+(defun (setf safety-hash-gethash) (new-value key safety-hash)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (setf (gethash key hash-table) new-value)))
+
+(defun safety-hash-table-count (safety-hash)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (hash-table-count hash-table)))
+
+(defun safety-hash-remhash (key safety-hash)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (remhash key hash-table)))
+
+
+;;; Higher-level multi-access & convenience functions.
+
+(defun safety-hash-gethash-or-lose (key safety-hash)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (multiple-value-bind (value foundp) (gethash key hash-table)
+      (if foundp
+          value
+          (error "Failed to find key ~A in SAFETY-HASH" key)))))
+
+(defun safety-hash-insert-unique (key value safety-hash)
+  (with-locked-safety-hash (hash-table) safety-hash
+    (if (nth-value 1 (gethash key hash-table))
+        (error "Collision for key ~A in SAFETY-HASH ~A" key safety-hash)
+        (setf (gethash key hash-table) value))))

--- a/app-ng/src/safety-hash/impl-bordeaux-threads.lisp
+++ b/app-ng/src/safety-hash/impl-bordeaux-threads.lisp
@@ -1,26 +1,10 @@
-;;;; safety-hash.lisp
+;;;; app-ng/src/safety-hash/impl-bordeaux-threads.lisp
 ;;;;
 ;;;; Author: appleby
-;;;;
-;;;;     Safety-hash!
-;;;;
-;;;;     Ah we can hash if we want to, we can leave your locks behind
-;;;;     Cause your threads don't hash and if they don't hash
-;;;;     Well they're are no threads of mine
-;;;;
-;;;; SAFETY-HASH implements a portable, thread-safe interface to basic CRUD operations for a
-;;;; globally-accessible hash-table-like object. SAFETY-HASHes are used in QVM-APP-NG to store
-;;;; PERSISTENT-QVMs and other objects which might persist between requests.
 ;;;;
 ;;;; The SAFETY-HASH implementation in this file is intended to be simple and portable (and probably
 ;;;; slow). This portable implementation acquires and releases a recursive per-object lock around
 ;;;; every operation. It depends on BORDEAUX-THREADS for the locking primitives.
-;;;;
-;;;; The SAFETY-HASH API sticks closely to the standard Common Lisp HASH-TABLE API, but doesn't
-;;;; attempt to be a drop-in replacement. Only functions actually needed in the parent QVM-APP-NG
-;;;; package are included. For example, some of the standard HASH-TABLE functions are missing
-;;;; (HASH-TABLE-SIZE, MAPHASH, etc.), and other functions are included here which have no direct
-;;;; counterpart for standard HASH-TABLEs (e.g. SAFETY-HASH-INSERT-UNIQUE).
 (in-package #:qvm-app-ng.safety-hash)
 
 (defstruct (safety-hash (:constructor %make-safety-hash))

--- a/app-ng/src/safety-hash/impl-bordeaux-threads.lisp
+++ b/app-ng/src/safety-hash/impl-bordeaux-threads.lisp
@@ -32,7 +32,8 @@
 
 (defun clrhash (safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (cl:clrhash hash-table)))
+    (cl:clrhash hash-table))
+  safety-hash)
 
 (defun gethash (key safety-hash &optional default)
   (with-locked-safety-hash (hash-table) safety-hash

--- a/app-ng/src/safety-hash/impl-sbcl.lisp
+++ b/app-ng/src/safety-hash/impl-sbcl.lisp
@@ -1,0 +1,62 @@
+;;;; app-ng/src/safety-hash/impl-sbcl.lisp
+;;;;
+;;;; Author: appleby
+;;;;
+;;;; The SAFETY-HASH implementation in this file relies on SBCL-specific HASH-TABLE extensions [1],
+;;;; namely the :SYNCHRONIZED keyword to MAKE-HASH-TABLE, plus SB-EXT:WITH-LOCKED-HASH-TABLE for
+;;;; multi-access operations.
+;;;;
+;;;; SB-SPROF indicates that this implementation is ~2x faster on SBCL than the one in
+;;;; impl-bordeaux-threads.lisp when running a naive insert/read/delete test in a tight loop.
+;;;;
+;;;; [1]: http://www.sbcl.org/manual/#Hash-Table-Extensions
+(in-package #:qvm-app-ng.safety-hash)
+
+(deftype safety-hash () 'hash-table)
+
+(defun safety-hash-p (object)
+  (typep object 'safety-hash))
+
+(defun call-with-locked-safety-hash (safety-hash function)
+  (sb-ext:with-locked-hash-table (safety-hash)
+    (funcall function safety-hash)))
+
+(defmacro with-locked-safety-hash ((hash-table) safety-hash &body body)
+  (check-type hash-table symbol)
+  `(call-with-locked-safety-hash ,safety-hash (lambda (,hash-table) ,@body)))
+
+
+;;; Standard HASH-TABLE API replacements.
+
+(defun make-safety-hash (&rest make-hash-table-args)
+  (apply #'make-hash-table :synchronized t make-hash-table-args))
+
+(defun clrhash (safety-hash)
+  (cl:clrhash safety-hash))
+
+(defun gethash (key safety-hash &optional default)
+  (cl:gethash key safety-hash default))
+
+(defun (setf gethash) (new-value key safety-hash)
+  (setf (cl:gethash key safety-hash) new-value))
+
+(defun hash-table-count (safety-hash)
+  (cl:hash-table-count safety-hash))
+
+(defun remhash (key safety-hash)
+  (cl:remhash key safety-hash))
+
+
+;;; Higher-level multi-access & convenience functions.
+
+(defun gethash-or-lose (key safety-hash)
+  (multiple-value-bind (value foundp) (cl:gethash key safety-hash)
+    (if foundp
+        value
+        (error "Failed to find key ~A in SAFETY-HASH" key))))
+
+(defun insert-unique (key value safety-hash)
+  (sb-ext:with-locked-hash-table (safety-hash)
+    (if (nth-value 1 (cl:gethash key safety-hash))
+        (error "Collision for key ~A in SAFETY-HASH" key)
+        (setf (cl:gethash key safety-hash) value))))

--- a/app-ng/src/safety-hash/interface.lisp
+++ b/app-ng/src/safety-hash/interface.lisp
@@ -1,0 +1,86 @@
+;;;; app-ng/src/safety-hash/impl-sbcl.lisp
+;;;;
+;;;; Author: appleby
+;;;;
+;;;; This file defines the interface that platform-specific implementations in the impl-*.lisp files
+;;;; are expected to follow, and will signal a compile-time error if any of the expected functions
+;;;; and/or macros are missing. Additionally, this file provides default documentation strings for
+;;;; the the expected interfaces.
+(in-package #:qvm-app-ng.safety-hash)
+
+(define-condition interface-error (simple-error) ())
+
+(defun interface-error (type symbol)
+  (error 'interface-error
+         :format-control "SAFETY-HASH: Failed to implement ~A of type ~A."
+         :format-arguments (list symbol type)))
+
+(defun check-required (type name lambda-list &optional documentation)
+  (declare (ignore lambda-list))
+  (check-type type (member defun defmacro))
+  (check-type documentation (or null string))
+  (assert (or (symbolp name)
+              (and (eq 'defun type) (consp name) (eq 'setf (car name)))))
+  (multiple-value-bind (doctype defined-p)
+      (ecase type
+        (defun (values 'function (and (fboundp name)
+                                      (or (consp name)
+                                          (not (macro-function name))))))
+        (defmacro (values 'function (and (fboundp name) (macro-function name)))))
+    (unless defined-p
+      (interface-error type name))
+    (unless (documentation name doctype)
+      (setf (documentation name doctype) documentation))))
+
+(defun check-all-required (specs)
+  (mapc (lambda (spec)
+          (apply #'check-required spec))
+        specs))
+
+(check-all-required
+ '((defun safety-hash-p (object)
+     "Is OBJECT a SAFETY-HASH?")
+
+   (defun call-with-locked-safety-hash (safety-hash function)
+     "Call FUNCTION with the SAFETY-HASH lock held.
+
+SAFETY-HASH is a SAFETY-HASH.
+
+FUNCTION is a function-designator for a FUNCTION of a single argument. It will be passed a reference to the locked SAFETY-HASH.
+
+Return the value of (FUNCALL FUNCTION SAFETY-HASH).")
+
+   (defmacro with-locked-safety-hash ((hash-table) safety-hash &body body)
+     "Lock SAFETY-HASH and execute BODY with HASH-TABLE bound to SAFETY-HASH's corresponding HASH-TABLE object.")
+
+   (defun make-safety-hash (&rest make-hash-table-args)
+     "Make a new SAFETY-HASH.
+
+Any arguments are passed through to MAKE-HASH-TABLE when initializing the underlying HASH-TABLE object.")
+
+   (defun clrhash (safety-hash)
+     "Remove all entries from SAFETY-HASH and return SAFETY-HASH.")
+
+   (defun gethash (key safety-hash &optional default)
+     "Lookup the value of KEY in SAFETY-HASH.")
+
+   (defun (setf gethash) (new-value key safety-hash)
+     "Set the entry for KEY to NEW-VALUE in SAFETY-HASH and return NEW-VALUE.")
+
+   (defun hash-table-count (safety-hash)
+     "Return the number of entries in SAFETY-HASH.")
+
+   (defun remhash (key safety-hash)
+     "Remove the entry in SAFETY-HASH associated with KEY.
+
+Return T if there was such an entry, or NIL if not.")
+
+   (defun gethash-or-lose (key safety-hash)
+     "Lookup KEY in SAFETY-HASH or signal an ERROR if no such key is present.
+
+Return the value corresponding to KEY on success.")
+
+   (defun insert-unique (key value safety-hash)
+     "Insert the KEY/VALUE pair into SAFETY-HASH, or signal an ERROR if KEY is already present.
+
+Return VALUE on success.")))

--- a/app-ng/src/safety-hash/interface.lisp
+++ b/app-ng/src/safety-hash/interface.lisp
@@ -1,4 +1,4 @@
-;;;; app-ng/src/safety-hash/impl-sbcl.lisp
+;;;; app-ng/src/safety-hash/interface.lisp
 ;;;;
 ;;;; Author: appleby
 ;;;;

--- a/app-ng/src/safety-hash/package.lisp
+++ b/app-ng/src/safety-hash/package.lisp
@@ -1,0 +1,23 @@
+;;;; app-ng/src/safety-hash/package.lisp
+;;;;
+;;;; Author: appleby
+
+(defpackage #:qvm-app-ng.safety-hash
+  (:use #:cl)
+  (:nicknames #:safety-hash)
+  (:shadow #:clrhash
+           #:gethash
+           #:hash-table-count
+           #:remhash)
+  (:export #:safety-hash
+           #:safety-hash-p
+           #:make-safety-hash
+           #:gethash-or-lose
+           #:insert-unique
+           #:call-with-locked-safety-hash
+           #:with-locked-safety-hash
+           ;; shadowing CL symbols
+           #:clrhash
+           #:gethash
+           #:hash-table-count
+           #:remhash))

--- a/app-ng/src/safety-hash/package.lisp
+++ b/app-ng/src/safety-hash/package.lisp
@@ -32,6 +32,7 @@
 (defpackage #:qvm-app-ng.safety-hash
   (:use #:cl)
   (:nicknames #:safety-hash)
+  ;; WARNING: You really really don't want to :USE this package.
   (:shadow #:clrhash
            #:gethash
            #:hash-table-count

--- a/app-ng/src/safety-hash/package.lisp
+++ b/app-ng/src/safety-hash/package.lisp
@@ -1,7 +1,34 @@
 ;;;; app-ng/src/safety-hash/package.lisp
 ;;;;
 ;;;; Author: appleby
-
+;;;;
+;;;;     Safety-hash!
+;;;;
+;;;;     Ah we can hash if we want to, we can leave your locks behind
+;;;;     Cause your threads don't hash and if they don't hash
+;;;;     Well they're no threads of mine
+;;;;
+;;;; The SAFETY-HASH package implements a (semi-)portable, thread-safe interface to basic CRUD
+;;;; operations for hash-table-like objects. SAFETY-HASHes are used in QVM-APP-NG to store
+;;;; PERSISTENT-QVMs and other objects which might persist between requests.
+;;;;
+;;;; The SAFETY-HASH API sticks closely to the standard Common Lisp HASH-TABLE API, but doesn't
+;;;; attempt to be a drop-in replacement. Only functions actually needed in the parent QVM-APP-NG
+;;;; package are included. For example, some of the standard HASH-TABLE functions are missing
+;;;; (HASH-TABLE-SIZE, MAPHASH, etc.), and other functions are included here which have no direct
+;;;; counterpart for standard HASH-TABLEs (e.g. SAFETY-HASH:INSERT-UNIQUE).
+;;;;
+;;;; The SAFETY-HASH package supports the following implementations:
+;;;;
+;;;;   - impl-bordeaux-threads.lisp: a portable (but slow) implementation that relies on
+;;;;     BORDEAUX-THREADS.
+;;;;
+;;;;   - impl-sbcl.lisp: an SBCL-specific version that relies on SBCL's :SYNCHRONIZED keyword to
+;;;;     MAKE-HASH-TABLE, plus SB-EXT:WITH-LOCKED-HASH-TABLE for multi-access operations.
+;;;;
+;;;; At a minimum, CCL, ECL, and LispWorks all claim to support thread-safe hash-tables, and
+;;;; therefore might also benefit from a platform-specific implementation. For links to docs for
+;;;; associated implementation-specific extensions, see: https://github.com/rigetti/qvm/issues/186
 (defpackage #:qvm-app-ng.safety-hash
   (:use #:cl)
   (:nicknames #:safety-hash)

--- a/app-ng/src/safety-hash/safety-hash.lisp
+++ b/app-ng/src/safety-hash/safety-hash.lisp
@@ -50,7 +50,7 @@
 ;;;;       (maphash (lambda (key value)
 ;;;;                  (setf (gethash key hash-table) (1+ value)))
 ;;;;                hash-table)
-(in-package #:qvm-app-ng)
+(in-package #:qvm-app-ng.safety-hash)
 
 (defstruct (safety-hash (:constructor %make-safety-hash))
   (lock  (error "Must provide LOCK")  :read-only t)
@@ -74,38 +74,38 @@
 (defun make-safety-hash (&rest make-hash-table-args)
   (%make-safety-hash :lock (bt:make-lock) :table (apply #'make-hash-table make-hash-table-args)))
 
-(defun safety-hash-clrhash (safety-hash)
+(defun clrhash (safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (clrhash hash-table)))
+    (cl:clrhash hash-table)))
 
-(defun safety-hash-gethash (key safety-hash &optional default)
+(defun gethash (key safety-hash &optional default)
   (with-locked-safety-hash (hash-table) safety-hash
-    (gethash key hash-table default)))
+    (cl:gethash key hash-table default)))
 
-(defun (setf safety-hash-gethash) (new-value key safety-hash)
+(defun (setf gethash) (new-value key safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (setf (gethash key hash-table) new-value)))
+    (setf (cl:gethash key hash-table) new-value)))
 
-(defun safety-hash-table-count (safety-hash)
+(defun hash-table-count (safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (hash-table-count hash-table)))
+    (cl:hash-table-count hash-table)))
 
-(defun safety-hash-remhash (key safety-hash)
+(defun remhash (key safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (remhash key hash-table)))
+    (cl:remhash key hash-table)))
 
 
 ;;; Higher-level multi-access & convenience functions.
 
-(defun safety-hash-gethash-or-lose (key safety-hash)
+(defun gethash-or-lose (key safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (multiple-value-bind (value foundp) (gethash key hash-table)
+    (multiple-value-bind (value foundp) (cl:gethash key hash-table)
       (if foundp
           value
           (error "Failed to find key ~A in SAFETY-HASH" key)))))
 
-(defun safety-hash-insert-unique (key value safety-hash)
+(defun insert-unique (key value safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
-    (if (nth-value 1 (gethash key hash-table))
+    (if (nth-value 1 (cl:gethash key hash-table))
         (error "Collision for key ~A in SAFETY-HASH ~A" key safety-hash)
-        (setf (gethash key hash-table) value))))
+        (setf (cl:gethash key hash-table) value))))

--- a/app-ng/src/safety-hash/safety-hash.lisp
+++ b/app-ng/src/safety-hash/safety-hash.lisp
@@ -79,5 +79,5 @@
 (defun insert-unique (key value safety-hash)
   (with-locked-safety-hash (hash-table) safety-hash
     (if (nth-value 1 (cl:gethash key hash-table))
-        (error "Collision for key ~A in SAFETY-HASH ~A" key safety-hash)
+        (error "Collision for key ~A in SAFETY-HASH" key)
         (setf (cl:gethash key hash-table) value))))

--- a/app-ng/src/safety-hash/safety-hash.lisp
+++ b/app-ng/src/safety-hash/safety-hash.lisp
@@ -66,7 +66,7 @@
 
 (defmacro with-locked-safety-hash ((hash-table) safety-hash &body body)
   (check-type hash-table symbol)
-  `(call-with-locked-safety-hash ,safety-hash (lambda (hash-table) ,@body)))
+  `(call-with-locked-safety-hash ,safety-hash (lambda (,hash-table) ,@body)))
 
 
 ;;; Standard HASH-TABLE API replacements.

--- a/app-ng/src/server.lisp
+++ b/app-ng/src/server.lisp
@@ -115,7 +115,7 @@ This function is analgous to hunchentoot's TBNL:GET-PARAMETER and and TBNL:POST-
   (with-locked-log ()
     (cl-syslog:format-log *logger* ':info
                           "~:[-~@[ (~A)~]~;~:*~A~@[ (~A)~]~] ~:[-~;~:*~A~] [~A] \"~A ~A~@[?~A~] ~
-                          ~A\" ~D ~:[-~;~:*~D~] \"~:[-~;~:*~A~]\" \"~:[-~;~:*~A~]\"~%"
+                          ~A\" ~D ~:[-~;~:*~D~] \"~:[-~;~:*~A~]\" \"~:[-~;~:*~A~]\" ~S~%"
                           (tbnl::remote-addr*)
                           (tbnl::header-in* :x-forwarded-for)
                           (tbnl::authorization)
@@ -127,7 +127,8 @@ This function is analgous to hunchentoot's TBNL:GET-PARAMETER and and TBNL:POST-
                           return-code
                           (tbnl::content-length*)
                           (tbnl::referer)
-                          (tbnl::user-agent))))
+                          (tbnl::user-agent)
+                          (tbnl:raw-post-data :request tbnl:*request* :force-text t))))
 
 (defmethod tbnl:acceptor-log-message ((acceptor rpc-acceptor) log-level format-string &rest format-arguments)
   (with-locked-log ()

--- a/app-ng/src/server.lisp
+++ b/app-ng/src/server.lisp
@@ -20,7 +20,7 @@
    :persistent-connections-p t))
 
 (defvar *rpc-acceptor* nil
-  "*RPC-ACCEPTOR* holds a reference to the RPC-ACCEPTOR instance created by last invocation of START-SERVER.")
+  "*RPC-ACCEPTOR* holds a reference to the RPC-ACCEPTOR instance created by the last invocation of START-SERVER.")
 
 (defun start-server-mode (&key (host +default-server-address+) (port +default-server-port+))
   "Start the HTTP server on the indicated HOST and PORT. Does not return."

--- a/app-ng/src/server.lisp
+++ b/app-ng/src/server.lisp
@@ -107,7 +107,7 @@ This function is analgous to hunchentoot's TBNL:GET-PARAMETER and and TBNL:POST-
       (tbnl:abort-request-handler (error-response (princ-to-string c))))))
 
 (defmethod tbnl:acceptor-status-message ((acceptor rpc-acceptor) http-status-code &key error &allow-other-keys)
-  (if (eql http-status-code tbnl:+http-internal-server-error+)
+  (if (eql http-status-code +http-internal-server-error+)
       (error-response error)
       (call-next-method)))
 

--- a/app-ng/src/server.lisp
+++ b/app-ng/src/server.lisp
@@ -1,6 +1,7 @@
-;;;; server.lisp
+;;;; app-ng/src/server.lisp
 ;;;;
 ;;;; Author: Robert Smith
+;;;;         appleby
 
 (in-package #:qvm-app-ng)
 

--- a/app-ng/src/utilities.lisp
+++ b/app-ng/src/utilities.lisp
@@ -1,6 +1,7 @@
-;;;; utilities.lisp
+;;;; app-ng/src/utilities.lisp
 ;;;;
 ;;;; Author: Robert Smith
+;;;;         appleby
 
 (in-package #:qvm-app-ng)
 

--- a/app-ng/src/uuid.lisp
+++ b/app-ng/src/uuid.lisp
@@ -1,4 +1,4 @@
-;;;; uuid.lisp
+;;;; app-ng/src/uuid.lisp
 ;;;;
 ;;;; Author: appleby
 (in-package #:qvm-app-ng)

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -9,30 +9,24 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
   (lambda (parameter)
     (and parameter (funcall parameter-parser parameter))))
 
-(defun parse-qvm-token (qvm-token)
+(defun %parse-uuid-token (token token-type-name)
   ;; Ensure it's a STRING before attempting to canonicalize the case. Otherwise, we'll get a
   ;; not-so-helpful error message.
-  (unless (typep qvm-token 'string)
-    (rpc-parameter-parse-error "Invalid persistent QVM token. Expected a v4 UUID string. Got ~S"
-                               qvm-token))
+  (unless (typep token 'string)
+    (rpc-parameter-parse-error "Invalid ~A token. Expected a v4 UUID string. Got ~S"
+                               token-type-name token))
 
-  (let ((canonicalized-token (canonicalize-persistent-qvm-token qvm-token)))
-    (unless (valid-persistent-qvm-token-p canonicalized-token)
-      (rpc-parameter-parse-error "Invalid persistent QVM token. Expected a v4 UUID. Got ~S"
-                                 qvm-token))
+  (let ((canonicalized-token (canonicalize-uuid-string token)))
+    (unless (valid-uuid-string-p canonicalized-token)
+      (rpc-parameter-parse-error "Invalid ~A token. Expected a v4 UUID. Got ~S"
+                                 token-type-name token))
     canonicalized-token))
+
+(defun parse-qvm-token (qvm-token)
+  (%parse-uuid-token qvm-token "persistent QVM"))
 
 (defun parse-job-token (job-token)
-  ;; TODO(appleby): unify PARSE-JOB-TOKEN and PARSE-QVM-TOKEN.
-  ;; Ensure it's a STRING before attempting to canonicalize the case. Otherwise, we'll get a
-  ;; not-so-helpful error message.
-  (unless (typep job-token 'string)
-    (rpc-parameter-parse-error "Invalid JOB token. Expected a v4 UUID string. Got ~S" job-token))
-
-  (let ((canonicalized-token (canonicalize-uuid-string job-token)))
-    (unless (valid-uuid-string-p canonicalized-token)
-      (rpc-parameter-parse-error "Invalid JOB token. Expected a v4 UUID. Got ~S" job-token))
-    canonicalized-token))
+  (%parse-uuid-token job-token "JOB"))
 
 (defun %parse-string-to-known-symbol (parameter-name parameter-string known-symbols
                                       &optional (package 'qvm-app-ng))

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -58,6 +58,9 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
   num-qubits)
 
 (defun valid-address-query-p (addresses)
+  "Is ADDRESSES a valid address query HASH-TABLE?
+
+Return T if ADDRESSES is a HASH-TABLE whose keys are STRINGs denoting DECLAREd memory names and whose values are either T or else a list of non-negative integers."
   (cond
     ((not (hash-table-p addresses)) nil)
     (t
@@ -72,6 +75,9 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
      t)))
 
 (defun valid-memory-contents-query-p (memory-contents)
+  "Is MEMORY-CONTENTS a valid memory-contents query HASH-TABLE?
+
+Return T if MEMORY-CONTENTS is a HASH-TABLE whose keys are STRINGs denoting DECLAREd memory names and whose values are a LIST of LISTs of length 2 where the first element of each pair is a non-negative INTEGER and the second element is either an INTEGER or REAL."
   (cond
     ((not (hash-table-p memory-contents)) nil)
     (t
@@ -94,12 +100,18 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
     (user-input-error
      "Invalid ADDRESSES parameter. The requested addresses should be a JSON object whose keys are ~
       DECLAREd memory names, and whose values are either the true value to request all memory, or ~
-      a list of non-negative integer indexes to request some memory."))
+      a list of non-negative integer indexes to request only the memory locations corresponding ~
+      to the given indexes."))
   addresses)
 
 (defun parse-memory-contents (memory-contents)
   (unless (valid-memory-contents-query-p memory-contents)
-    (user-input-error "Invalid MEMORY-CONTENTS."))
+    (user-input-error
+     "Invalid MEMORY-CONTENTS. The requested MEMORY-CONTENTS should be a JSON object whose keys are ~
+      DECLAREd memory names and whose values are a list of pairs where the first element of each ~
+      pair is a non-negative integer index into the memory region and the second element is either ~
+      an INTEGER or REAL value that should be stored at the corresponding index of the corresponding ~
+      memory region."))
   memory-contents)
 
 (defun parse-quil-string (string)

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -52,7 +52,7 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
   (%parse-string-to-known-symbol 'allocation-method allocation-method +available-allocation-methods+))
 
 (defun parse-num-qubits (num-qubits)
-  (unless (typep num-qubits `(integer 0))
+  (unless (typep num-qubits '(integer 0))
     (user-input-error "Invalid NUM-QUBITS. Expected a non-negative integer. Got ~S"
                       num-qubits))
   num-qubits)

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -93,7 +93,7 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
                                                 (= 2 (length entry))
                                                 (integerp (first entry))
                                                 (not (minusp (first entry)))
-                                                (typep (second entry) '(or integer real complex))))
+                                                (typep (second entry) '(or integer real))))
                                          v)))
                   (return-from valid-memory-contents-query-p nil)))
               memory-contents)

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -129,7 +129,10 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
   noise)
 
 (defun parse-sub-request (sub-request)
-  (let ((json (parse-json-or-lose sub-request)))
-    (when (member (gethash "type" json) '("create-job" "run-program-async") :test #'string=)
-      (rpc-bad-request-error "Invalid create-job SUB-REQUEST: ~S." sub-request))
-    json))
+  (unless (hash-table-p sub-request)
+    (rpc-bad-request-error "Invalid create-job SUB-REQUEST: not a valid JSON object: ~A" sub-request))
+  (when (member (gethash "type" sub-request) '("create-job" "run-program-async") :test #'string=)
+    (rpc-bad-request-error "Invalid create-job SUB-REQUEST type field: ~S."
+                           (with-output-to-string (*standard-output*)
+                             (yason:encode sub-request))))
+  sub-request)

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -121,7 +121,7 @@ Return a function that accepts a single PARAMETER and calls PARAMETER-PARSER on 
 (defun parse-sub-request (sub-request)
   (unless (hash-table-p sub-request)
     (user-input-error "Invalid create-job SUB-REQUEST: not a valid JSON object: ~A" sub-request))
-  (when (member (gethash "type" sub-request) '("create-job" "run-program-async") :test #'string=)
+  (when (string= "create-job" (gethash "type" sub-request))
     (user-input-error "Invalid create-job SUB-REQUEST type field: ~S."
                       (with-output-to-string (*standard-output*)
                         (yason:encode sub-request))))

--- a/app-ng/src/validators.lisp
+++ b/app-ng/src/validators.lisp
@@ -1,3 +1,6 @@
+;;;; app-ng/src/validators.lisp
+;;;;
+;;;; Author: appleby
 (in-package #:qvm-app-ng)
 
 (defun optionally (parameter-parser)

--- a/app-ng/tests/package.lisp
+++ b/app-ng/tests/package.lisp
@@ -1,6 +1,7 @@
 ;;;; app-ng/tests/package.lisp
 ;;;;
-;;;; Author: appleby
+;;;; Author: Nik Tezak
+;;;;         appleby
 
 (fiasco:define-test-package #:qvm-app-ng-tests
   (:use #:qvm-app-ng)

--- a/app-ng/tests/test-concurrency.lisp
+++ b/app-ng/tests/test-concurrency.lisp
@@ -10,7 +10,7 @@
                                  :allocation-method "native"
                                  :simulation-method "pure-state"
                                  :num-qubits 1))
-                      (token (extract-token response)))
+                      (token (gethash "token" (qvm-app-ng::response-data response))))
                  (lparallel:submit-task channel #'qvm-info token)))
              (qvm-info (token)
                (qvm-app-ng::handle-qvm-info :qvm-token token)
@@ -43,7 +43,7 @@
                                  :allocation-method "native"
                                  :simulation-method "pure-state"
                                  :num-qubits 1))
-                      (token (extract-token response)))
+                      (token (gethash "token" (qvm-app-ng::response-data response))))
                  (lparallel:submit-task channel #'delete-qvm token)))
              (delete-qvm (token)
                (qvm-app-ng::handle-delete-qvm :qvm-token token)))
@@ -64,7 +64,7 @@
          (response (qvm-app-ng::handle-create-qvm :allocation-method "native"
                                                   :simulation-method "pure-state"
                                                   :num-qubits 1))
-         (token (extract-token response)))
+         (token (gethash "token" (qvm-app-ng::response-data response))))
     (unwind-protect
          (lparallel:task-handler-bind ((error  #'lparallel:invoke-transfer-error))
            (loop :repeat num-tasks :do

--- a/app-ng/tests/test-concurrency.lisp
+++ b/app-ng/tests/test-concurrency.lisp
@@ -23,7 +23,7 @@
              (delete-qvm (token)
                (qvm-app-ng::handle-delete-qvm :qvm-token token)))
 
-      (lparallel:task-handler-bind ((error  #'lparallel:invoke-transfer-error))
+      (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
         (loop :repeat num-tasks :do
           (lparallel:submit-task channel #'create-qvm))
         (loop :repeat (* 4 num-tasks) :do
@@ -48,7 +48,7 @@
              (delete-qvm (token)
                (qvm-app-ng::handle-delete-qvm :qvm-token token)))
 
-      (lparallel:task-handler-bind ((error  #'lparallel:invoke-transfer-error))
+      (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
         (loop :repeat num-tasks :do
           (lparallel:submit-task channel #'create-qvm))
         (loop :repeat (* 2 num-tasks) :do
@@ -66,7 +66,7 @@
                                                   :num-qubits 1))
          (token (gethash "token" (qvm-app-ng::response-data response))))
     (unwind-protect
-         (lparallel:task-handler-bind ((error  #'lparallel:invoke-transfer-error))
+         (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
            (loop :repeat num-tasks :do
              (lparallel:submit-task channel
                                     (lambda ()

--- a/app-ng/tests/test-entry-point.lisp
+++ b/app-ng/tests/test-entry-point.lisp
@@ -4,7 +4,7 @@
   (qvm-app-ng::%entry-point (append '("--verbose" "0") argv)))
 
 (deftest test-initial-rpc-request-version ()
-  (is (string= (with-output-to-string (*error-output*)
+  (is (string= (with-output-to-string (*standard-output*)
                  (qvm-app-ng::show-version))
                (with-output-to-string (*standard-output*)
                  (enter-quietly '("--rpc-request" "{\"type\": \"version\"}"))))))
@@ -21,14 +21,14 @@
 
 (deftest test-show-version ()
   (dolist (flag '("-v" "--version"))
-    (is (string= (with-output-to-string (*error-output*)
+    (is (string= (with-output-to-string (*standard-output*)
                    (qvm-app-ng::show-version))
-                 (with-output-to-string (*error-output*)
+                 (with-output-to-string (*standard-output*)
                    (enter-quietly (list flag)))))))
 
 (deftest test-show-help ()
   (dolist (flag '("-h" "--help"))
-    (is (string= (with-output-to-string (*error-output*)
+    (is (string= (with-output-to-string (*standard-output*)
                    (qvm-app-ng::show-help))
-                 (with-output-to-string (*error-output*)
+                 (with-output-to-string (*standard-output*)
                    (enter-quietly (list flag)))))))

--- a/app-ng/tests/test-handlers.lisp
+++ b/app-ng/tests/test-handlers.lisp
@@ -2,9 +2,12 @@
 
 (deftest test-handle-run-program ()
   ;; This test demonstrates calling a handler directly, rather than through the HTTP interface.
-  (is (equalp (yason:parse (qvm-app-ng::handle-run-program
-                            :allocation-method "native"
-                            :simulation-method "pure-state"
-                            :compiled-quil "DECLARE ro BIT; X 0; MEASURE 0 ro[0]"
-			    :addresses (alexandria:plist-hash-table '("ro" t))))
-              (alexandria:plist-hash-table '("ro" ((1))) :test 'equal))))
+  (let ((response (qvm-app-ng::handle-run-program
+                   :allocation-method "native"
+                   :simulation-method "pure-state"
+                   :compiled-quil "DECLARE ro BIT; X 0; MEASURE 0 ro[0]"
+                   :addresses (alexandria:plist-hash-table '("ro" t))))
+        (expected (alexandria:plist-hash-table '("ro" ((1))) :test 'equal)))
+    (is (typep response 'qvm-app-ng::json-response))
+    (is (= qvm-app-ng::+http-ok+ (qvm-app-ng::response-status response)))
+    (is (equalp expected (qvm-app-ng::response-data response)))))

--- a/app-ng/tests/test-job.lisp
+++ b/app-ng/tests/test-job.lisp
@@ -1,0 +1,11 @@
+(in-package :qvm-app-ng-tests)
+
+(deftest test-jobs ()
+  (let ((job (make-job (lambda () (sleep 2) 10))))
+    (is (eql (job-status job) job-status-fresh))
+    (job-start job)
+    (is (eql (job-status job) job-status-running))
+    (is (= (job-result job) 10))
+    (is (adt:match job-status (job-status job)
+          ((job-status-finished result) result)
+          (_ nil)))))

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -990,7 +990,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                          :response-re "Deleted persistent QVM"))))))
 
 (deftest test-rpc-api-create-qvm-invalid-requests ()
-  "Test input validate for the create-qvm call."
+  "Test input validation for the create-qvm call."
   (with-rpc-server (url)
     ;; invalid simulation-method
     (check-request (simple-request url

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -153,7 +153,8 @@ The CREATE-JOB request is expected to return with status 200 OK.
 Ensure that the job is deleted afterwards."
   (let ((job-token (extract-and-validate-token
                     (check-request (simple-request url :type "create-job"
-                                                       :sub-request (plist->json json-plist))))))
+                                                       :sub-request (plist->json json-plist))
+                                   :status 202))))
     (unwind-protect
          (simple-request url :type "job-result" :job-token job-token)
       (simple-request url :type "delete-job" :job-token job-token))))
@@ -458,6 +459,7 @@ Ensure that the job is deleted afterwards."
                                                           :allocation-method allocation-method
                                                           :simulation-method simulation-method
                                                           :num-qubits num-qubits)
+                                          :status 201
                                           :response-re +rpc-response-token-scanner+))
                  (token (extract-and-validate-token response)))
 
@@ -514,13 +516,14 @@ Ensure that the job is deleted afterwards."
                                                       :allocation-method "native"
                                                       :simulation-method "pure-state"
                                                       :num-qubits 2)
+                                      :status 201
                                       :response-re +rpc-response-token-scanner+)))
            (job-token (extract-and-validate-token
                        (check-request (simple-request url
                                                       :type "run-program-async"
                                                       :qvm-token qvm-token
                                                       :compiled-quil "DECLARE ro BIT; DECLARE alpha REAL; MOVE alpha 0.0; WAIT; RX(alpha) 0; MEASURE 0 ro")
-                                      :status 200))))
+                                      :status 202))))
 
       (check-request (simple-request url :type "qvm-info" :qvm-token qvm-token)
                      :response-callback (response-json-fields-checker '(("state" "WAITING"))))
@@ -583,6 +586,7 @@ Ensure that the job is deleted afterwards."
                                                    :allocation-method "native"
                                                    :simulation-method "pure-state"
                                                    :num-qubits 2)
+                                      :status 201
                                       :response-re +rpc-response-token-scanner+)))
            (job-token (extract-and-validate-token
                        (check-request (simple-request url
@@ -592,7 +596,7 @@ Ensure that the job is deleted afterwards."
                                                                      :qvm-token ,qvm-token
                                                                      :compiled-quil "DECLARE ro BIT; DECLARE alpha REAL; MOVE alpha 0.0; WAIT; RX(alpha) 0; MEASURE 0 ro"
                                                                      :addresses ,+all-ro-addresses+)))
-                                      :status 200))))
+                                      :status 202))))
 
       (check-request (job-request url :type "qvm-info" :qvm-token qvm-token)
                      :response-callback (response-json-fields-checker '(("state" "WAITING"))))
@@ -668,6 +672,7 @@ Ensure that the job is deleted afterwards."
                                                         :num-qubits 1
                                                         :gate-noise gate-noise
                                                         :measurement-noise measurement-noise)
+                                        :status 201
                                         :response-re +rpc-response-token-scanner+))
                (token (extract-and-validate-token response)))
 
@@ -794,6 +799,7 @@ Ensure that the job is deleted afterwards."
                                                     :allocation-method "native"
                                                     :simulation-method "pure-state"
                                                     :num-qubits 1)
+                                    :status 201
                                     :response-re +rpc-response-token-scanner+))
            (token (extract-and-validate-token response)))
 
@@ -846,6 +852,7 @@ Ensure that the job is deleted afterwards."
                                                        :allocation-method allocation-method
                                                        :simulation-method simulation-method
                                                        :num-qubits 2)
+                                       :status 201
                                        :response-re +rpc-response-token-scanner+))
               (token (extract-and-validate-token response)))
 
@@ -911,7 +918,8 @@ Ensure that the job is deleted afterwards."
                        (simple-request url
                                        :type "create-job"
                                        :sub-request (plist->json '(:type "qvm-info"
-                                                                   :qvm-token "bogus")))))))
+                                                                   :qvm-token "bogus")))
+                       :status 202))))
 
       (check-request (simple-request url :type "job-info" :job-token job-token)
                      :response-callback
@@ -933,7 +941,8 @@ Ensure that the job is deleted afterwards."
                       (check-request
                        (simple-request url
                                        :type "create-job"
-                                       :sub-request (plist->json '(:type "version")))))))
+                                       :sub-request (plist->json '(:type "version")))
+                       :status 202))))
 
       (check-request (job-request url :type "job-info" :job-token job-token)
                      :response-callback

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -65,6 +65,8 @@ Also calls PLIST-LOWERCASE-KEYS to STRING-DOWNCASE the PLIST keys."
              (yason:parse response-string))))
 
 (defun invalidate-token (qvm-token)
+  ;; Replacing all 4's with 5's is guaranteed to produce an invalid v4 UUID, since it will overwrite
+  ;; the version field.
   (substitute #\5 #\4 qvm-token))
 
 (defun extract-token (response)

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -515,10 +515,10 @@ Ensure that the job is deleted afterwards."
     (dolist (allocation-method +allocation-method-strings+)
       (dolist (simulation-method +simulation-method-strings+)
         (dolist (num-qubits '(0 1 16))
-          ;; EXPECTED-BYTES is duplicating the calculation in QVM-APP-NG::MEMORY-REQUIRED-FOR-QVM.
+          ;; EXPECTED-BYTES is duplicating the calculation in QVM-APP-NG::OCTETS-REQUIRED-FOR-QVM.
           ;; We could just call that function here, but then we'd only be testing the HTTP
           ;; interface, not the calculation. By duplicating the calculation here, this test will
-          ;; still catch any bugs that creep in to QVM-APP-NG::MEMORY-REQUIRED-FOR-QVM, at the
+          ;; still catch any bugs that creep in to QVM-APP-NG::OCTETS-REQUIRED-FOR-QVM, at the
           ;; expense of needing to be separately kept in sync as support for more SIMULATION-METHODs
           ;; and noise models are added.
           (let ((expected-bytes

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -457,7 +457,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                      :simulation-method "pure-state"
                      :compiled-quil +generic-x-0-quil-program+
                      :addresses +all-ro-addresses+)
-     :response-callback (response-json-fields-checker `(("ro" ((1 0))))))
+     :response-callback (response-json-fields-checker '(("ro" ((1 0))))))
 
     ;; explicit index list
     (check-request
@@ -467,7 +467,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                      :simulation-method "pure-state"
                      :compiled-quil +generic-x-0-quil-program+
                      :addresses (plist->hash-table '("ro" (0))))
-     :response-callback (response-json-fields-checker `(("ro" ((1))))))
+     :response-callback (response-json-fields-checker '(("ro" ((1))))))
 
     ;; non-consecutive indices + "non ro" named register
     (check-request
@@ -477,7 +477,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                      :simulation-method "pure-state"
                      :compiled-quil "DECLARE mem BIT[3]; X 3; MEASURE 0 mem[0]; MEASURE 3 mem[2]"
                      :addresses (plist->hash-table '("mem" (0 2))))
-     :response-callback (response-json-fields-checker `(("mem" ((0 1))))))
+     :response-callback (response-json-fields-checker '(("mem" ((0 1))))))
 
     ;; invalid register index OOB
     (check-request
@@ -1126,6 +1126,9 @@ Failed to find key #1# in SAFETY-HASH")))))
 
       ;; upper case token also accepted
       (check-request (simple-request url :type "qvm-info" :qvm-token (string-upcase token))
+
+
+
                      :response-re "PURE-STATE-QVM")
 
       ;; delete on existing token
@@ -1166,7 +1169,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                                         :qvm-token token
                                         :compiled-quil +generic-x-0-quil-program+
                                         :addresses +all-ro-addresses+)
-                        :response-callback (response-json-fields-checker `(("ro" ((1 0))))))
+                        :response-callback (response-json-fields-checker '(("ro" ((1 0))))))
 
          ;; I 0: qubit 0 remains in excited state
          (check-request (simple-request url
@@ -1174,7 +1177,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                                         :qvm-token token
                                         :compiled-quil "DECLARE ro BIT[2]; I 0; MEASURE 0 ro[0]"
                                         :addresses +all-ro-addresses+)
-                        :response-callback (response-json-fields-checker `(("ro" ((1 0))))))
+                        :response-callback (response-json-fields-checker '(("ro" ((1 0))))))
 
          ;; X 0: flips qubit 0 back to ground state
          (check-request (simple-request url
@@ -1182,7 +1185,7 @@ Failed to find key #1# in SAFETY-HASH")))))
                                         :qvm-token token
                                         :compiled-quil +generic-x-0-quil-program+
                                         :addresses +all-ro-addresses+)
-                        :response-callback (response-json-fields-checker `(("ro" ((0 0))))))
+                        :response-callback (response-json-fields-checker '(("ro" ((0 0))))))
 
          ;; cleanup
          (check-request (simple-request url :type "delete-qvm" :qvm-token token)

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -437,6 +437,28 @@ Ensure that the job is deleted afterwards."
                      :addresses (alexandria:plist-hash-table '("mem" (0 2))))
      :response-callback (response-json-fields-checker `(("mem" ((0 1))))))
 
+    ;; invalid register index OOB
+    (check-request
+     (simple-request url
+                     :type "run-program"
+                     :allocation-method "native"
+                     :simulation-method "pure-state"
+                     :compiled-quil +generic-x-0-quil-program+
+                     :addresses (alexandria:plist-hash-table '("ro" (0 2))))
+     :status 500
+     :response-re "qvm_error")
+
+    ;; invalid negative register index
+    (check-request
+     (simple-request url
+                     :type "run-program"
+                     :allocation-method "native"
+                     :simulation-method "pure-state"
+                     :compiled-quil +generic-x-0-quil-program+
+                     :addresses (alexandria:plist-hash-table '("ro" (-1))))
+     :status 400
+     :response-re "qvm_error")
+
     ;; non-existent named register
     (check-request
      (simple-request url

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -101,7 +101,8 @@ HOST defaults to 127.0.0.1 and PORT defaults to a randomly assigned port."
   (unwind-protect
        (funcall function body-or-stream status-code headers uri stream must-close reason-phrase)
     (progn
-      (close stream)
+      (when (streamp stream)
+        (close stream))
       (when (streamp body-or-stream)
         (close body-or-stream)))))
 

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -361,7 +361,7 @@ Ensure that the job is deleted afterwards."
                                    :simulation-method "pure-state"
                                    :compiled-quil "(defgate FOO (:as :permutation) #(0 2 3 1))"
                                    :addresses +empty-hash-table+)
-                   :status 500)
+                   :status 400)
 
     ;; NB: the :ADDRESSES parameter is complicated enough that it gets a separate test in
     ;; TEST-RPC-API-RUN-PROGRAM-ADDRESSES.

--- a/app-ng/tests/test-rpc-api.lisp
+++ b/app-ng/tests/test-rpc-api.lisp
@@ -64,11 +64,6 @@ Also calls PLIST-LOWERCASE-KEYS to STRING-DOWNCASE the PLIST keys."
     (funcall (hash-table-fields-checker fields)
              (yason:parse response-string))))
 
-(defun plist-downcase-keys (plist)
-  (assert (evenp (length plist)))
-  (loop :for (key value) :on plist :by #'cddr
-        :nconc (list (string-downcase key) value)))
-
 (defun invalidate-token (qvm-token)
   (substitute #\5 #\4 qvm-token))
 

--- a/app-ng/tests/test-safety-hash.lisp
+++ b/app-ng/tests/test-safety-hash.lisp
@@ -1,0 +1,186 @@
+(in-package #:qvm-app-ng-tests)
+
+;;; Basic API sanity tests
+
+(deftest test-make-safety-hash ()
+  ;; exhaustive test of :TEST keyword
+  (dolist (test (list 'eq 'eql 'equal 'equalp #'eq #'eql #'equal #'equalp))
+    (is (typep (qvm-app-ng::make-safety-hash :test test)
+               'qvm-app-ng::safety-hash)))
+
+  ;; a smattering of other standard args
+  (is (typep (qvm-app-ng::make-safety-hash :size 1 :rehash-size 1 :rehash-threshold 1)
+             'qvm-app-ng::safety-hash))
+  (is (typep (qvm-app-ng::make-safety-hash :size 10 :rehash-size 4.5 :rehash-threshold 0.5)
+             'qvm-app-ng::safety-hash)))
+
+(deftest test-safety-hash-clrhash ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))
+    (qvm-app-ng::safety-hash-clrhash h)
+    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))
+    (dotimes (i 10)
+      (setf (qvm-app-ng::safety-hash-gethash i h) 0))
+    (is (= 10 (qvm-app-ng::safety-hash-table-count h)))
+    (qvm-app-ng::safety-hash-clrhash h)
+    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))))
+
+(deftest test-safety-hash-gethash ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (is (null (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h))))
+    (is (null (nth-value 1 (qvm-app-ng::safety-hash-gethash 0 h))))
+    (is (= 2  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h 2))))
+    (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)
+    (is (= 0  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h))))
+    (is (not (null (nth-value 1 (qvm-app-ng::safety-hash-gethash 0 h)))))
+    (is (= 0  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h 2))))
+    (setf (qvm-app-ng::safety-hash-gethash 0 h) 1)
+    (is (= 1  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h))))
+    (is (not (null (nth-value 1 (qvm-app-ng::safety-hash-gethash 0 h)))))
+    (is (= 1  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h 2))))))
+
+(deftest test-safety-hash-table-count ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (dotimes (i 10)
+      (is (= i (qvm-app-ng::safety-hash-table-count h)))
+      (setf (qvm-app-ng::safety-hash-gethash i h) 0))
+    (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)
+    (is (= 10 (qvm-app-ng::safety-hash-table-count h)))))
+
+(deftest test-safety-hash-remhash ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (is (null (qvm-app-ng::safety-hash-remhash 0 h)))
+    (dotimes (i 10)
+      (setf (qvm-app-ng::safety-hash-gethash i h) 0))
+    (dotimes (i 10)
+      (is (= (- 10 i) (qvm-app-ng::safety-hash-table-count h)))
+      (is (not (null (qvm-app-ng::safety-hash-remhash i h)))))
+    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))))
+
+(deftest test-safety-hash-gethash-or-lose ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (signals error (qvm-app-ng::safety-hash-gethash-or-lose 0 h))
+    (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)
+    (is (= 0 (qvm-app-ng::safety-hash-gethash-or-lose 0 h)))))
+
+(deftest test-safety-hash-insert-unique ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (is (= 0 (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)))
+    (signals error (qvm-app-ng::safety-hash-insert-unique 0 0 h))))
+
+(deftest test-call-with-locked-safety-hash ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (is (= 0 (qvm-app-ng::call-with-locked-safety-hash h (lambda (hash-table)
+                                                           (setf (gethash 0 hash-table) 0)))))
+    (is (= 0 (qvm-app-ng::safety-hash-gethash 0 h)))))
+
+(deftest test-with-locked-safety-hash ()
+  (let ((h (qvm-app-ng::make-safety-hash)))
+    (qvm-app-ng::with-locked-safety-hash (hash-table) h
+      (setf (gethash 0 hash-table) 0))
+    (is (= 0 (qvm-app-ng::safety-hash-gethash 0 h)))))
+
+;;; Concurrency tests
+
+(deftest test-safety-hash-concurrent-writers-one-key ()
+  (qvm:prepare-for-parallelization)
+  (let ((num-tasks (max 2 (lparallel:kernel-worker-count)))
+        (writes-per-task 10000)
+        (channel (lparallel:make-channel))
+        (start-queue (lparallel.queue:make-queue))
+        (h (qvm-app-ng::make-safety-hash)))
+    (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
+      (loop :for task-id :below num-tasks :do
+        (lparallel:submit-task channel
+                               (lambda (task-id)
+                                 (lparallel.queue:pop-queue start-queue)
+                                 (loop :repeat writes-per-task :do
+                                   (setf (qvm-app-ng::safety-hash-gethash 0 h) task-id)))
+                               task-id))
+      (loop :repeat num-tasks :do
+        (lparallel.queue:push-queue t start-queue))
+      (loop :repeat num-tasks :do
+        (lparallel:receive-result channel))
+      (is (= 1 (qvm-app-ng::safety-hash-table-count h)))
+      (is (member (qvm-app-ng::safety-hash-gethash 0 h)
+                  (alexandria:iota num-tasks))))))
+
+
+(deftest test-safety-hash-concurrent-writers-many-unique-keys ()
+  (qvm:prepare-for-parallelization)
+  (let ((num-tasks (max 2 (lparallel:kernel-worker-count)))
+        (writes-per-task 10000)
+        (channel (lparallel:make-channel))
+        (start-queue (lparallel.queue:make-queue))
+        (h (qvm-app-ng::make-safety-hash)))
+    (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
+      (loop :for i :below num-tasks :do
+        (lparallel:submit-task channel
+                               (lambda (task-id)
+                                 (lparallel.queue:pop-queue start-queue)
+                                 (loop :for k :from task-id :below (+ task-id writes-per-task) :do
+                                   (setf (qvm-app-ng::safety-hash-gethash k h) task-id)))
+                               (* i writes-per-task)))
+      (loop :repeat num-tasks :do
+        (lparallel.queue:push-queue t start-queue))
+      (loop :repeat num-tasks :do
+        (lparallel:receive-result channel))
+      (is (= (qvm-app-ng::safety-hash-table-count h) (* num-tasks writes-per-task))))))
+
+(deftest test-safety-hash-concurrent-write-and-clrhash ()
+  (qvm:prepare-for-parallelization)
+  (let ((num-tasks (* 2 (lparallel:kernel-worker-count)))
+        (writes-per-task 10000)
+        (channel (lparallel:make-channel))
+        (start-queue (lparallel.queue:make-queue))
+        (h (qvm-app-ng::make-safety-hash)))
+    (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
+      (loop :with num-tasks/2 := (floor num-tasks 2)
+            :for i :below num-tasks/2 :do
+              (lparallel:submit-task channel
+                                     (lambda (task-id)
+                                       (lparallel.queue:pop-queue start-queue)
+                                       (loop :with start := (* task-id writes-per-task)
+                                             :for k :from start :below (+ start writes-per-task) :do
+                                               (setf (qvm-app-ng::safety-hash-gethash i h) task-id)))
+                                     i)
+              (lparallel:submit-task channel
+                                     (lambda ()
+                                       (lparallel.queue:pop-queue start-queue)
+                                       (loop :repeat writes-per-task :do
+                                         (qvm-app-ng::safety-hash-clrhash h)))))
+      (loop :repeat num-tasks :do
+        (lparallel.queue:push-queue t start-queue))
+      (loop :repeat num-tasks :do
+        (lparallel:receive-result channel))
+      (is (< (qvm-app-ng::safety-hash-table-count h) (* num-tasks writes-per-task))))))
+
+(deftest test-safety-hash-concurrent-write-and-remhash ()
+  (qvm:prepare-for-parallelization)
+  (let ((num-tasks (* 2 (lparallel:kernel-worker-count)))
+        (writes-per-task 10000)
+        (channel (lparallel:make-channel))
+        (start-queue (lparallel.queue:make-queue))
+        (keys-queue (lparallel.queue:make-queue :fixed-capacity 1000))
+        (h (qvm-app-ng::make-safety-hash)))
+    (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
+      (loop :with num-tasks/2 := (floor num-tasks 2)
+            :for i :below num-tasks/2 :do
+              (lparallel:submit-task channel
+                                     (lambda (start)
+                                       (lparallel.queue:pop-queue start-queue)
+                                       (loop :for k :from start :below (+ start writes-per-task) :do
+                                         (setf (qvm-app-ng::safety-hash-gethash k h) start)
+                                         (lparallel.queue:push-queue k keys-queue)))
+                                     (* i writes-per-task))
+              (lparallel:submit-task channel
+                                     (lambda ()
+                                       (lparallel.queue:pop-queue start-queue)
+                                       (loop :repeat writes-per-task
+                                             :for k := (lparallel.queue:pop-queue keys-queue) :do
+                                               (assert (qvm-app-ng::safety-hash-remhash k h))))))
+      (loop :repeat num-tasks :do
+        (lparallel.queue:push-queue t start-queue))
+      (loop :repeat num-tasks :do
+        (lparallel:receive-result channel))
+      (is (= 0 (qvm-app-ng::safety-hash-table-count h))))))

--- a/app-ng/tests/test-safety-hash.lisp
+++ b/app-ng/tests/test-safety-hash.lisp
@@ -5,80 +5,79 @@
 (deftest test-make-safety-hash ()
   ;; exhaustive test of :TEST keyword
   (dolist (test (list 'eq 'eql 'equal 'equalp #'eq #'eql #'equal #'equalp))
-    (is (typep (qvm-app-ng::make-safety-hash :test test)
-               'qvm-app-ng::safety-hash)))
+    (is (safety-hash:safety-hash-p (safety-hash:make-safety-hash :test test))))
 
   ;; a smattering of other standard args
-  (is (typep (qvm-app-ng::make-safety-hash :size 1 :rehash-size 1 :rehash-threshold 1)
-             'qvm-app-ng::safety-hash))
-  (is (typep (qvm-app-ng::make-safety-hash :size 10 :rehash-size 4.5 :rehash-threshold 0.5)
-             'qvm-app-ng::safety-hash)))
+  (is (safety-hash:safety-hash-p
+       (safety-hash:make-safety-hash :size 1 :rehash-size 1 :rehash-threshold 1)))
+  (is (safety-hash:safety-hash-p
+       (safety-hash:make-safety-hash :size 10 :rehash-size 4.5 :rehash-threshold 0.5))))
 
 (deftest test-safety-hash-clrhash ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))
-    (qvm-app-ng::safety-hash-clrhash h)
-    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))
+  (let ((h (safety-hash:make-safety-hash)))
+    (is (= 0 (safety-hash:hash-table-count h)))
+    (safety-hash:clrhash h)
+    (is (= 0 (safety-hash:hash-table-count h)))
     (dotimes (i 10)
-      (setf (qvm-app-ng::safety-hash-gethash i h) 0))
-    (is (= 10 (qvm-app-ng::safety-hash-table-count h)))
-    (qvm-app-ng::safety-hash-clrhash h)
-    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))))
+      (setf (safety-hash:gethash i h) 0))
+    (is (= 10 (safety-hash:hash-table-count h)))
+    (safety-hash:clrhash h)
+    (is (= 0 (safety-hash:hash-table-count h)))))
 
 (deftest test-safety-hash-gethash ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (is (null (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h))))
-    (is (null (nth-value 1 (qvm-app-ng::safety-hash-gethash 0 h))))
-    (is (= 2  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h 2))))
-    (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)
-    (is (= 0  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h))))
-    (is (not (null (nth-value 1 (qvm-app-ng::safety-hash-gethash 0 h)))))
-    (is (= 0  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h 2))))
-    (setf (qvm-app-ng::safety-hash-gethash 0 h) 1)
-    (is (= 1  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h))))
-    (is (not (null (nth-value 1 (qvm-app-ng::safety-hash-gethash 0 h)))))
-    (is (= 1  (nth-value 0 (qvm-app-ng::safety-hash-gethash 0 h 2))))))
+  (let ((h (safety-hash:make-safety-hash)))
+    (is (null (nth-value 0 (safety-hash:gethash 0 h))))
+    (is (null (nth-value 1 (safety-hash:gethash 0 h))))
+    (is (= 2  (nth-value 0 (safety-hash:gethash 0 h 2))))
+    (setf (safety-hash:gethash 0 h) 0)
+    (is (= 0  (nth-value 0 (safety-hash:gethash 0 h))))
+    (is (not (null (nth-value 1 (safety-hash:gethash 0 h)))))
+    (is (= 0  (nth-value 0 (safety-hash:gethash 0 h 2))))
+    (setf (safety-hash:gethash 0 h) 1)
+    (is (= 1  (nth-value 0 (safety-hash:gethash 0 h))))
+    (is (not (null (nth-value 1 (safety-hash:gethash 0 h)))))
+    (is (= 1  (nth-value 0 (safety-hash:gethash 0 h 2))))))
 
-(deftest test-safety-hash-table-count ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
+(deftest test-safety-hash-hash-table-count ()
+  (let ((h (safety-hash:make-safety-hash)))
     (dotimes (i 10)
-      (is (= i (qvm-app-ng::safety-hash-table-count h)))
-      (setf (qvm-app-ng::safety-hash-gethash i h) 0))
-    (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)
-    (is (= 10 (qvm-app-ng::safety-hash-table-count h)))))
+      (is (= i (safety-hash:hash-table-count h)))
+      (setf (safety-hash:gethash i h) 0))
+    (setf (safety-hash:gethash 0 h) 0)
+    (is (= 10 (safety-hash:hash-table-count h)))))
 
 (deftest test-safety-hash-remhash ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (is (null (qvm-app-ng::safety-hash-remhash 0 h)))
+  (let ((h (safety-hash:make-safety-hash)))
+    (is (null (safety-hash:remhash 0 h)))
     (dotimes (i 10)
-      (setf (qvm-app-ng::safety-hash-gethash i h) 0))
+      (setf (safety-hash:gethash i h) 0))
     (dotimes (i 10)
-      (is (= (- 10 i) (qvm-app-ng::safety-hash-table-count h)))
-      (is (not (null (qvm-app-ng::safety-hash-remhash i h)))))
-    (is (= 0 (qvm-app-ng::safety-hash-table-count h)))))
+      (is (= (- 10 i) (safety-hash:hash-table-count h)))
+      (is (not (null (safety-hash:remhash i h)))))
+    (is (= 0 (safety-hash:hash-table-count h)))))
 
 (deftest test-safety-hash-gethash-or-lose ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (signals error (qvm-app-ng::safety-hash-gethash-or-lose 0 h))
-    (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)
-    (is (= 0 (qvm-app-ng::safety-hash-gethash-or-lose 0 h)))))
+  (let ((h (safety-hash:make-safety-hash)))
+    (signals error (safety-hash:gethash-or-lose 0 h))
+    (setf (safety-hash:gethash 0 h) 0)
+    (is (= 0 (safety-hash:gethash-or-lose 0 h)))))
 
 (deftest test-safety-hash-insert-unique ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (is (= 0 (setf (qvm-app-ng::safety-hash-gethash 0 h) 0)))
-    (signals error (qvm-app-ng::safety-hash-insert-unique 0 0 h))))
+  (let ((h (safety-hash:make-safety-hash)))
+    (is (= 0 (setf (safety-hash:gethash 0 h) 0)))
+    (signals error (safety-hash:insert-unique 0 0 h))))
 
 (deftest test-call-with-locked-safety-hash ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (is (= 0 (qvm-app-ng::call-with-locked-safety-hash h (lambda (hash-table)
+  (let ((h (safety-hash:make-safety-hash)))
+    (is (= 0 (safety-hash:call-with-locked-safety-hash h (lambda (hash-table)
                                                            (setf (gethash 0 hash-table) 0)))))
-    (is (= 0 (qvm-app-ng::safety-hash-gethash 0 h)))))
+    (is (= 0 (safety-hash:gethash 0 h)))))
 
 (deftest test-with-locked-safety-hash ()
-  (let ((h (qvm-app-ng::make-safety-hash)))
-    (qvm-app-ng::with-locked-safety-hash (hash-table) h
+  (let ((h (safety-hash:make-safety-hash)))
+    (safety-hash:with-locked-safety-hash (hash-table) h
       (setf (gethash 0 hash-table) 0))
-    (is (= 0 (qvm-app-ng::safety-hash-gethash 0 h)))))
+    (is (= 0 (safety-hash:gethash 0 h)))))
 
 ;;; Concurrency tests
 
@@ -88,21 +87,21 @@
         (writes-per-task 10000)
         (channel (lparallel:make-channel))
         (start-queue (lparallel.queue:make-queue))
-        (h (qvm-app-ng::make-safety-hash)))
+        (h (safety-hash:make-safety-hash)))
     (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
       (loop :for task-id :below num-tasks :do
         (lparallel:submit-task channel
                                (lambda (task-id)
                                  (lparallel.queue:pop-queue start-queue)
                                  (loop :repeat writes-per-task :do
-                                   (setf (qvm-app-ng::safety-hash-gethash 0 h) task-id)))
+                                   (setf (safety-hash:gethash 0 h) task-id)))
                                task-id))
       (loop :repeat num-tasks :do
         (lparallel.queue:push-queue t start-queue))
       (loop :repeat num-tasks :do
         (lparallel:receive-result channel))
-      (is (= 1 (qvm-app-ng::safety-hash-table-count h)))
-      (is (member (qvm-app-ng::safety-hash-gethash 0 h)
+      (is (= 1 (safety-hash:hash-table-count h)))
+      (is (member (safety-hash:gethash 0 h)
                   (alexandria:iota num-tasks))))))
 
 
@@ -112,20 +111,20 @@
         (writes-per-task 10000)
         (channel (lparallel:make-channel))
         (start-queue (lparallel.queue:make-queue))
-        (h (qvm-app-ng::make-safety-hash)))
+        (h (safety-hash:make-safety-hash)))
     (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
       (loop :for i :below num-tasks :do
         (lparallel:submit-task channel
                                (lambda (task-id)
                                  (lparallel.queue:pop-queue start-queue)
                                  (loop :for k :from task-id :below (+ task-id writes-per-task) :do
-                                   (setf (qvm-app-ng::safety-hash-gethash k h) task-id)))
+                                   (setf (safety-hash:gethash k h) task-id)))
                                (* i writes-per-task)))
       (loop :repeat num-tasks :do
         (lparallel.queue:push-queue t start-queue))
       (loop :repeat num-tasks :do
         (lparallel:receive-result channel))
-      (is (= (qvm-app-ng::safety-hash-table-count h) (* num-tasks writes-per-task))))))
+      (is (= (safety-hash:hash-table-count h) (* num-tasks writes-per-task))))))
 
 (deftest test-safety-hash-concurrent-write-and-clrhash ()
   (qvm:prepare-for-parallelization)
@@ -133,7 +132,7 @@
         (writes-per-task 10000)
         (channel (lparallel:make-channel))
         (start-queue (lparallel.queue:make-queue))
-        (h (qvm-app-ng::make-safety-hash)))
+        (h (safety-hash:make-safety-hash)))
     (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
       (loop :with num-tasks/2 := (floor num-tasks 2)
             :for i :below num-tasks/2 :do
@@ -142,18 +141,18 @@
                                        (lparallel.queue:pop-queue start-queue)
                                        (loop :with start := (* task-id writes-per-task)
                                              :for k :from start :below (+ start writes-per-task) :do
-                                               (setf (qvm-app-ng::safety-hash-gethash i h) task-id)))
+                                               (setf (safety-hash:gethash i h) task-id)))
                                      i)
               (lparallel:submit-task channel
                                      (lambda ()
                                        (lparallel.queue:pop-queue start-queue)
                                        (loop :repeat writes-per-task :do
-                                         (qvm-app-ng::safety-hash-clrhash h)))))
+                                         (safety-hash:clrhash h)))))
       (loop :repeat num-tasks :do
         (lparallel.queue:push-queue t start-queue))
       (loop :repeat num-tasks :do
         (lparallel:receive-result channel))
-      (is (< (qvm-app-ng::safety-hash-table-count h) (* num-tasks writes-per-task))))))
+      (is (< (safety-hash:hash-table-count h) (* num-tasks writes-per-task))))))
 
 (deftest test-safety-hash-concurrent-write-and-remhash ()
   (qvm:prepare-for-parallelization)
@@ -162,7 +161,7 @@
         (channel (lparallel:make-channel))
         (start-queue (lparallel.queue:make-queue))
         (keys-queue (lparallel.queue:make-queue :fixed-capacity 1000))
-        (h (qvm-app-ng::make-safety-hash)))
+        (h (safety-hash:make-safety-hash)))
     (lparallel:task-handler-bind ((error #'lparallel:invoke-transfer-error))
       (loop :with num-tasks/2 := (floor num-tasks 2)
             :for i :below num-tasks/2 :do
@@ -170,7 +169,7 @@
                                      (lambda (start)
                                        (lparallel.queue:pop-queue start-queue)
                                        (loop :for k :from start :below (+ start writes-per-task) :do
-                                         (setf (qvm-app-ng::safety-hash-gethash k h) start)
+                                         (setf (safety-hash:gethash k h) start)
                                          (lparallel.queue:push-queue k keys-queue)))
                                      (* i writes-per-task))
               (lparallel:submit-task channel
@@ -178,9 +177,9 @@
                                        (lparallel.queue:pop-queue start-queue)
                                        (loop :repeat writes-per-task
                                              :for k := (lparallel.queue:pop-queue keys-queue) :do
-                                               (assert (qvm-app-ng::safety-hash-remhash k h))))))
+                                               (assert (safety-hash:remhash k h))))))
       (loop :repeat num-tasks :do
         (lparallel.queue:push-queue t start-queue))
       (loop :repeat num-tasks :do
         (lparallel:receive-result channel))
-      (is (= 0 (qvm-app-ng::safety-hash-table-count h))))))
+      (is (= 0 (safety-hash:hash-table-count h))))))

--- a/app-ng/tests/test-safety-hash.lisp
+++ b/app-ng/tests/test-safety-hash.lisp
@@ -2,7 +2,7 @@
 
 ;;; Basic API sanity tests
 
-(deftest test-make-safety-hash ()
+(deftest test-safety-hash-make-safety-hash ()
   ;; exhaustive test of :TEST keyword
   (dolist (test (list 'eq 'eql 'equal 'equalp #'eq #'eql #'equal #'equalp))
     (is (safety-hash:safety-hash-p (safety-hash:make-safety-hash :test test))))
@@ -67,13 +67,13 @@
     (is (= 0 (setf (safety-hash:gethash 0 h) 0)))
     (signals error (safety-hash:insert-unique 0 0 h))))
 
-(deftest test-call-with-locked-safety-hash ()
+(deftest test-safety-hash-call-with-locked-safety-hash ()
   (let ((h (safety-hash:make-safety-hash)))
     (is (= 0 (safety-hash:call-with-locked-safety-hash h (lambda (hash-table)
                                                            (setf (gethash 0 hash-table) 0)))))
     (is (= 0 (safety-hash:gethash 0 h)))))
 
-(deftest test-with-locked-safety-hash ()
+(deftest test-safety-hash-with-locked-safety-hash ()
   (let ((h (safety-hash:make-safety-hash)))
     (safety-hash:with-locked-safety-hash (hash-table) h
       (setf (gethash 0 hash-table) 0))

--- a/app-ng/tests/test-safety-hash.lisp
+++ b/app-ng/tests/test-safety-hash.lisp
@@ -116,7 +116,6 @@
       (is (member (safety-hash:gethash 0 h)
                   (alexandria:iota num-tasks))))))
 
-
 (deftest test-safety-hash-concurrent-writers-many-unique-keys ()
   (qvm:prepare-for-parallelization)
   (let ((num-tasks (max 2 (lparallel:kernel-worker-count)))

--- a/app-ng/tests/test-safety-hash.lisp
+++ b/app-ng/tests/test-safety-hash.lisp
@@ -79,6 +79,18 @@
       (setf (gethash 0 hash-table) 0))
     (is (= 0 (safety-hash:gethash 0 h)))))
 
+(deftest test-safety-hash-recursive-locking ()
+  (let ((h (safety-hash:make-safety-hash)))
+    (safety-hash:with-locked-safety-hash (hash-table-1) h
+      (setf (gethash 0 hash-table-1) 0)
+      (safety-hash:with-locked-safety-hash (hash-table-2) h
+        (is (eq hash-table-1 hash-table-2))
+        (setf (gethash 1 hash-table-1) 1)
+        (setf (gethash 2 hash-table-2) 2)))
+    (is (= 0 (safety-hash:gethash 0 h)))
+    (is (= 1 (safety-hash:gethash 1 h)))
+    (is (= 2 (safety-hash:gethash 2 h)))))
+
 ;;; Concurrency tests
 
 (deftest test-safety-hash-concurrent-writers-one-key ()

--- a/app-ng/tests/test-validators.lisp
+++ b/app-ng/tests/test-validators.lisp
@@ -21,13 +21,13 @@
   (is (eq 'qvm-app-ng::full-density-matrix (qvm-app-ng::parse-simulation-method "full-density-matrix")))
   (is (eq 'qvm-app-ng::pure-state (qvm-app-ng::parse-simulation-method "PURE-STATE")))
   (is (eq 'qvm-app-ng::full-density-matrix (qvm-app-ng::parse-simulation-method "FULL-DENSITY-MATRIX")))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-simulation-method ""))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-simulation-method "parse-simulation-method"))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-simulation-method "cons"))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-simulation-method "pure-states")))
 
 (deftest test-parse-allocation-method ()
@@ -35,11 +35,11 @@
   (is (eq 'qvm-app-ng::foreign (qvm-app-ng::parse-allocation-method "foreign")))
   (is (eq 'qvm-app-ng::native (qvm-app-ng::parse-allocation-method "NATIVE")))
   (is (eq 'qvm-app-ng::foreign (qvm-app-ng::parse-allocation-method "FOREIGN")))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-allocation-method ""))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-allocation-method "parse-allocation-method"))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-allocation-method "most-positive-fixnum"))
-  (signals qvm-app-ng::rpc-parameter-parse-error
+  (signals qvm-app-ng::user-input-error
     (qvm-app-ng::parse-allocation-method "natives")))

--- a/qvm-app-ng-tests.asd
+++ b/qvm-app-ng-tests.asd
@@ -26,4 +26,5 @@
                (:file "test-handlers")
                (:file "test-concurrency")
                (:file "test-safety-hash")
+               (:file "test-job")
                (:file "suite")))

--- a/qvm-app-ng-tests.asd
+++ b/qvm-app-ng-tests.asd
@@ -25,4 +25,5 @@
                (:file "test-rpc-api")
                (:file "test-handlers")
                (:file "test-concurrency")
+               (:file "test-safety-hash")
                (:file "suite")))

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -11,6 +11,7 @@
                #:qvm
                #:alexandria
                #:bordeaux-threads
+               #:cl-algebraic-data-type
                #:cl-syslog
                #:command-line-arguments
                #:global-vars
@@ -43,4 +44,5 @@
                (:file "handlers")
                (:file "qvm-app-ng-version")
                (:file "impl/sbcl" :if-feature :sbcl)
-               (:file "entry-point")))
+               (:file "entry-point")
+               (:file "job")))

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -25,9 +25,10 @@
   :entry-point "qvm-app-ng::asdf-entry-point"
   :components ((:module "safety-hash"
                 :serial t
-                :components ((:file "package")
-                             (:file "impl-bordeaux-threads" :if-feature (:not :sbcl))
-                             (:file "impl-sbcl" :if-feature :sbcl)))
+                :components
+                ((:file "package")
+                 (:file "impl-bordeaux-threads" :if-feature (:or (:not :sbcl) :qvm-app-ng-generic-safety-hash))
+                 (:file "impl-sbcl" :if-feature (:and :sbcl (:not :qvm-app-ng-generic-safety-hash)))))
                (:file "package")
                (:file "globals")
                (:file "utilities")

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -36,6 +36,7 @@
                (:file "utilities")
                (:file "uuid")
                (:file "logging")
+               (:file "http-status")
                (:file "errors")
                (:file "validators")
                (:file "make-qvm")

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -45,4 +45,5 @@
                (:file "qvm-app-ng-version")
                (:file "impl/sbcl" :if-feature :sbcl)
                (:file "entry-point")
-               (:file "job")))
+               (:file "job")
+               (:file "jobbo")))

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -26,7 +26,8 @@
   :components ((:module "safety-hash"
                 :serial t
                 :components ((:file "package")
-                             (:file "safety-hash")))
+                             (:file "impl-bordeaux-threads" :if-feature (:not :sbcl))
+                             (:file "impl-sbcl" :if-feature :sbcl)))
                (:file "package")
                (:file "globals")
                (:file "utilities")

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -41,6 +41,7 @@
                (:file "validators")
                (:file "make-qvm")
                (:file "persistent-qvm")
+               (:file "response")
                (:file "server")
                (:file "handlers")
                (:file "qvm-app-ng-version")

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -23,7 +23,11 @@
   :pathname "app-ng/src/"
   :serial t
   :entry-point "qvm-app-ng::asdf-entry-point"
-  :components ((:file "package")
+  :components ((:module "safety-hash"
+                :serial t
+                :components ((:file "package")
+                             (:file "safety-hash")))
+               (:file "package")
                (:file "globals")
                (:file "utilities")
                (:file "uuid")
@@ -31,7 +35,6 @@
                (:file "errors")
                (:file "validators")
                (:file "make-qvm")
-               (:file "safety-hash")
                (:file "persistent-qvm")
                (:file "server")
                (:file "handlers")

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -28,7 +28,8 @@
                 :components
                 ((:file "package")
                  (:file "impl-bordeaux-threads" :if-feature (:or (:not :sbcl) :qvm-app-ng-generic-safety-hash))
-                 (:file "impl-sbcl" :if-feature (:and :sbcl (:not :qvm-app-ng-generic-safety-hash)))))
+                 (:file "impl-sbcl" :if-feature (:and :sbcl (:not :qvm-app-ng-generic-safety-hash)))
+                 (:file "interface")))
                (:file "package")
                (:file "globals")
                (:file "utilities")

--- a/qvm-app-ng.asd
+++ b/qvm-app-ng.asd
@@ -31,6 +31,7 @@
                (:file "errors")
                (:file "validators")
                (:file "make-qvm")
+               (:file "safety-hash")
                (:file "persistent-qvm")
                (:file "server")
                (:file "handlers")

--- a/qvm.asd
+++ b/qvm.asd
@@ -36,8 +36,7 @@
                ;; For allocation info.
                #+sbcl #:sb-introspect
                ;; Portable *features*
-               #:trivial-features
-               )
+               #:trivial-features)
   :in-order-to ((asdf:test-op (asdf:test-op #:qvm-tests)))
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))


### PR DESCRIPTION
This PR includes implementations of the following API methods:

- Persistent QVM
  - create-qvm
  - qvm-info
  - delete-qvm
  - read-memory
  - write-memory
  - resume
- Program execution
  - run-program
  - run-program-async
- Job stuff
  - create-job
  - job-info
  - delete-job
  - job-result
- Misc
  - version
  - qvm-memory-estimate

~~No support for allocation types or noise models.~~ Partial support for allocation types (native and foreign) and noise models (currently only Pauli channel noise). No reconfiguration of persistent QVMs. ~~Only simulation-method (pure-state or full-density-matrix) and number of qubits are specified at creation time.~~

The `run-program` API call can act either on a persistent QVM (if passed a qvm-token parameter) or else on an ephemeral QVM (if passed simulation and allocation methods). It's interface is similar to the current `multishot` call, but without multiple trials. A `singleshot`, if you will.

API handlers are defined via a macro `DEFINE-RPC-HANDLER` which is similar in spirit to hunchentoot's `DEFINE-EASY-HANDLER`, but rather than dispatching based on the URI path, it dispatches based on the "type" field in the JSON request body, similar to the way the existing API dispatch works. Named parameters in the lambda-list of `DEFINE-RPC-HANDLER` are also populated from the JSON request body, as opposed to being initialized from GET/POST parameters as is the case for `DEFINE-EASY-HANDLER`.

~~This is still undercooked and woefully underdocumented, but posting now for exposure.~~

TODO

- [x] concurrency tests
- [x] comments / docstrings
- [x] basic v1 job api

Resolves #39