### PR TITLE
Add app-ng directory to LICENSE.txt spiel

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,15 @@
 Copyright 2016-2019 Rigetti Computing
 
 
-All source code, except that which is contained in the `app` directory
-and subdirectories thereof, is licensed under the Apache License
-version 2.0, contained in the remainder of this file.
+All source code, except that which is contained in the `app` and
+`app-ng` directories and subdirectories thereof, is licensed under 
+the Apache License version 2.0, contained in the remainder of this
+file.
 
-Source code contained in the `app` directory and subdirectories
-thereof is licensed under the GNU Affero General Public License
-version 3.0. See (`app/LICENSE.txt`)[app/LICENSE.txt].
+Source code contained in the `app` and `app-ng` directories and 
+subdirectories thereof is licensed under the GNU Affero General 
+Public License version 3.0. See (`app/LICENSE.txt`)[app/LICENSE.txt]
+and (`app-ng/LICENSE.txt`)[app-ng/LICENSE.txt], respectively.
 
 N.B. All of the ASDF systems are documented with their license:
 
@@ -22,6 +24,8 @@ N.B. All of the ASDF systems are documented with their license:
     QVM-TESTS is licensed under Apache License 2.0 (See LICENSE.txt)
     QVM-APP is licensed under GNU Affero General Public License v3.0 (See app/LICENSE.txt)
     QVM-APP-TESTS is licensed under GNU Affero General Public License v3.0 (See app/LICENSE.txt)
+    QVM-APP-NG is licensed under GNU Affero General Public License v3.0 (See app-ng/LICENSE.txt)
+    QVM-APP-NG-TESTS is licensed under GNU Affero General Public License v3.0 (See app-ng/LICENSE.txt)
 
 
                               * * * * *


### PR DESCRIPTION
I'm not sure if this needs to happen since the intention is for qvm-app-ng to be temporary and eventually replace qvm-app, but figured it's worth bringing up. If we do merge this, we'll need to file an issue to remember to undo it when qvm-app-ng becomes qvm-app.