### PR TITLE
Ensure that a value is returned from HANDLE-REQUEST

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -699,7 +699,7 @@ Version ~A is available from https://www.rigetti.com/forest~%"
                :taskmaster (make-instance 'tbnl:one-thread-per-connection-taskmaster)))
   (when (null (dispatch-table *app*))
     (push
-     (create-prefix/method-dispatcher "/" ':POST 'handle-post-request)
+     (create-prefix/method-dispatcher "/" ':POST 'handle-post-request-and-cleanup)
      (dispatch-table *app*)))
   (tbnl:start *app*))
 

--- a/app/src/handle-request.lisp
+++ b/app/src/handle-request.lisp
@@ -185,14 +185,17 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
                                    :measurement-noise measurement-noise)
            (load-time-value
             (with-output-to-string (s)
-              (yason:encode t s))))))))
+              (yason:encode t s)))))))))
 
-  (when (eq *allocation-description* 'qvm:c-allocation)
-    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    ;; Trigger the garbage collector to ensure that foreign memory is freed
-    ;; (see issue #198).
-    ;;
-    ;; TODO: This is a temporary fix and is not 100% satisfactory because it
-    ;; potentially stops all threads for GC after each request.
-    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    (tg:gc :full t)))
+(defun handle-post-request-and-cleanup (request)
+  "Call HANDLE-POST-REQUEST and do any necessary cleanup after (like gc)."
+  (unwind-protect (handle-post-request request)
+    (when (eq *allocation-description* 'qvm:c-allocation)
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+      ;; Trigger the garbage collector to ensure that foreign memory is freed
+      ;; (see issue #198).
+      ;;
+      ;; TODO: This is a temporary fix and is not 100% satisfactory because it
+      ;; potentially stops all threads for GC after each request.
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+      (tg:gc :full t))))


### PR DESCRIPTION
The garbage collection added at the end of HANDLE-REQUEST in #199 prevents HANDLE-REQUEST from returning a value. Some of the handlers write to the response stream directly, but others just return a value, which hunchentoot handles sending back to the client.