### PR TITLE
changing the default :initarg of channel-qvm to be valid

### DIFF
--- a/src/channel-qvm.lisp
+++ b/src/channel-qvm.lisp
@@ -41,12 +41,13 @@
     :initarg :noise-model
     :accessor noise-model))
   (:default-initargs
-   :noise-model nil)
+   :noise-model (make-noise-model nil))
   (:documentation "The CHANNEL-QVM is a QVM that supports a fully explicit NOISE-MODEL. The NOISE-MODEL is an explicit definition of where and how different channels should be applied to a program running in the CHANNEL-QVM."))
 
 (defmethod initialize-instance :after ((qvm channel-qvm) &rest args)
   ;; Initializes an instance of a CHANNEL-QVM.
   (declare (ignore args))
+  (check-type (noise-model qvm) noise-model)
   (setf
    ;; Initialize the TRIAL-AMPLITUDES to an empty array of the correct
    ;; size

--- a/src/noise-models.lisp
+++ b/src/noise-models.lisp
@@ -41,8 +41,9 @@
 ;;; instructions.
 (defconstant +maxpriority+ 20)
 (defconstant +minpriority+ 0)
-(deftype noise-priority () `(integer ,+minpriority+ ,+maxpriority+))
 (alexandria:define-constant +default-noise-predicate-name+ "NOISE-NAME" :test #'string=)
+
+(deftype noise-priority () `(integer ,+minpriority+ ,+maxpriority+))
 
 (deftype noise-position ()
   "Describes the position of a noise rule relative to an instruction. Should the noise be applied :BEFORE or :AFTER the instruction is executed?" 

--- a/tests/channel-qvm-tests.lisp
+++ b/tests/channel-qvm-tests.lisp
@@ -20,13 +20,25 @@
          (q (make-instance 'qvm::channel-qvm :number-of-qubits 2  :noise-model nm)))
     (is (= 3 (length (qvm::noise-rules (qvm::noise-model q)))))
     ;; Check noise rules are ordered by priority
-    (is (>= (qvm::priority (qvm::noise-predicate (nth 0 (qvm::noise-rules (qvm::noise-model q)))))
-            (qvm::priority (qvm::noise-predicate (nth 1 (qvm::noise-rules (qvm::noise-model q)))))
-            (qvm::priority (qvm::noise-predicate (nth 2 (qvm::noise-rules (qvm::noise-model q)))))))
+    (is (>= (qvm::priority (qvm::noise-predicate 
+                            (nth 0 (qvm::noise-rules (qvm::noise-model q)))))
+            (qvm::priority (qvm::noise-predicate 
+                            (nth 1 (qvm::noise-rules (qvm::noise-model q)))))
+            (qvm::priority (qvm::noise-predicate 
+                            (nth 2 (qvm::noise-rules (qvm::noise-model q)))))))
     ;; Check that each noise rule has the correct number of operation elements.
-    (is (= 2 (length (qvm::operation-elements (nth 0 (qvm::noise-rules (qvm::noise-model q)))))))
-    (is (= 3 (length (qvm::operation-elements (nth 1 (qvm::noise-rules (qvm::noise-model q)))))))
-    (is (= 1 (length (qvm::operation-elements (nth 2 (qvm::noise-rules (qvm::noise-model q)))))))))
+    (is (= 2 (length (qvm::operation-elements 
+                      (nth 0 (qvm::noise-rules (qvm::noise-model q)))))))
+    (is (= 3 (length (qvm::operation-elements 
+                      (nth 1 (qvm::noise-rules (qvm::noise-model q)))))))
+    (is (= 1 (length (qvm::operation-elements 
+                      (nth 2 (qvm::noise-rules (qvm::noise-model q))))))))
+  ;; Test channel-qvm with no noise-model
+  (let ((channel-qvm (make-instance 'channel-qvm :number-of-qubits 2))
+        (program (quil:parse-quil "DECLARE R0 BIT; H 0; CNOT 0 1")))
+    (load-program channel-qvm program :supersede-memory-subsystem t)
+    (run channel-qvm))
+  (signals error (make-instance 'channel-qvm :number-of-qubits 2 :noise-model nil)))
 
 (deftest test-rule-matches-instr-p ()
   ;; Test that RULE-MATCHES-INSTR-P correctly finds matches between


### PR DESCRIPTION
#210 

The channel-qvm expects its :noise-model slot to be a noise-model object, but it's default initarg is nil. This causes errors when a channel-qvm is created without a defined noise-model argument. To fix this I: 

- changed the default noise-model initarg of `channel-qvm` to be a `noise-model` with an empty set of noise-rules

- I added a check to `initialize-instance` to ensure that the `noise-model slot of `channel-qvm` is of type `noise-model`

- added checks to a test in `tests/channel-qvm`