### PR TITLE
removing old :AMPLITUDE initarg references in qvm-app

### DIFF
--- a/app/src/configure-qvm.lisp
+++ b/app/src/configure-qvm.lisp
@@ -76,7 +76,7 @@
                                                                             :classical-memory-model
                                                                             classical-memory-model)
                                  :state state)))
-           (when fin (tg:finalize q fin))
+           (when fin (tg:finalize state fin))
            q)))
       (t
        (let ((gate-noise (or gate-noise '(0.0 0.0 0.0)))
@@ -96,7 +96,7 @@
                                     :measure-y (elt measurement-noise 1)
                                     :measure-z (elt measurement-noise 2)
                                     :state state)))
-             (when fin (tg:finalize q fin))
+             (when fin (tg:finalize state fin))
              q)))))))
 
 

--- a/dqvm/tests/program-tests.lisp
+++ b/dqvm/tests/program-tests.lisp
@@ -22,10 +22,12 @@
   "Run PARSED-PROGRAM on a PURE-STATE-QVM with qubit size NUMBER-OF-QUBITS and return the wavefunction."
   (let* ((qvm:*compile-before-running* nil)
          (number-of-amplitudes (expt 2 number-of-qubits))
+         (state (make-instance 'qvm:pure-state :num-qubits number-of-qubits
+                                               :amplitudes (or initial-wavefunction
+                                                               (make-debug-wavefunction number-of-amplitudes))))
          (qvm (make-instance 'qvm:pure-state-qvm
                              :number-of-qubits number-of-qubits
-                             :amplitudes (or initial-wavefunction
-                                             (make-debug-wavefunction number-of-amplitudes)))))
+                             :state state)))
     (qvm:load-program qvm parsed-program)
     (qvm:run qvm)
     (qvm::amplitudes qvm)))


### PR DESCRIPTION
Before the qvm state representation refactor, `:AMPLITUDES` was an initarg for the different QVM classes to store the wavefunction data of a qvm. This functionality is now replaced by the QVM's `STATE`, and `:AMPLITUDES` is no longer a valid initarg for any QVM. This PR changes the `QVM-APP` to call the `:STATE` initarg instead of the `:AMPLITUDES` initarg when `make-instance`ing a QVM. 

This could possibly be more cleanly fixed by having more elegant `make-xxx-qvm` functions that can take pre-allocated amplitudes as arguments for the different types of QVMs. Since these functions do not exist, the QVM-APP uses `make-instance` when creating a QVM with an already allocated amplitudes vector. 