### PR TITLE
Update quicklisp_version to 2019-11-30 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # specify the dependency versions (can be overriden with --build_arg)
 ARG quilc_version=1.14.0
-ARG quicklisp_version=2019-07-11
+ARG quicklisp_version=2019-11-30
 
 # use multi-stage builds to independently pull dependency versions
 FROM rigetti/quilc:$quilc_version as quilc


### PR DESCRIPTION
~~Attempting to resolve `-edge` build failures like [this one](https://gitlab.com/rigetti/forest/qvm/-/jobs/372229634) by updating quicklisp dependency. Too lazy to test docker builds locally, pls ignore for now. kthanxbye.~~

Resolve `-edge` build failures like [this one](https://gitlab.com/rigetti/forest/qvm/-/jobs/372229634) by updating the quicklisp dependency.

QVM itself does not require the latest quicklisp, but quilc does because of it's recent magicl update to 0.6.5 (I think).