### PR TITLE
Use cl-quil's tools for safe resolution of included files

### DIFF
--- a/app/src/benchmark-programs.lisp
+++ b/app/src/benchmark-programs.lisp
@@ -5,7 +5,7 @@
 (in-package #:qvm-app)
 
 (defun bell-program (n)
-  (safely-parse-quil-string
+  (quil:safely-parse-quil
    (with-output-to-string (*standard-output*)
      (format t "DECLARE ro BIT[~D]~%" n)
      (format t "H 0~%")
@@ -73,7 +73,7 @@
     (qft-circuit (loop :for i :below n :collect i))))
 
 (defun hadamard-program (n)
-  (safely-parse-quil-string
+  (quil:safely-parse-quil
    (with-output-to-string (*standard-output*)
      (dotimes (i n)
        (format t "H ~D~%" i)))))
@@ -82,7 +82,7 @@
   "Create a loop that has NUM-LOOPS iterations and NUM-NOPS NOP instructions per iteration."
   (check-type num-loops unsigned-byte)
   (check-type num-nops unsigned-byte)
-  (safely-parse-quil-string
+  (quil:safely-parse-quil
    (with-output-to-string (*standard-output*)
      (write-line "DECLARE counter INTEGER")
      (write-line "DECLARE done BIT")
@@ -107,7 +107,7 @@
 
 We are assuming the CNOTs are dense on an even number of qubits."
   (assert (plusp rx-layers))
-  (safely-parse-quil-string
+  (quil:safely-parse-quil
    (with-output-to-string (*standard-output*)
      ;; Initial RX layer.
      (loop :for q :below n :do
@@ -127,7 +127,7 @@ We are assuming the CNOTs are dense on an even number of qubits."
 
 (defun interleaved-measurements-program (n)
   (assert (>= n 2))
-  (safely-parse-quil-string
+  (quil:safely-parse-quil
    (with-output-to-string (*standard-output*)
      (dotimes (q n)
        (format t "RX(~F) ~D~%" (random (* 2 pi)) q))

--- a/app/src/globals.lisp
+++ b/app/src/globals.lisp
@@ -8,7 +8,6 @@
 (defvar *qubit-limit* nil)              ; Maximum no. of qubits.
 (defvar *num-workers* nil)
 (defvar *time-limit* nil)
-(defvar *safe-include-directory* nil)
 (defvar *app* nil)
 (defvar *debug* nil)
 

--- a/app/src/handle-request.lisp
+++ b/app/src/handle-request.lisp
@@ -82,7 +82,7 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
                 (num-trials (gethash "trials" js))
                 (isns (get-quil-instrs-field js))
                 (quil (let ((quil::*allow-unresolved-applications* t))
-                        (process-quil (safely-parse-quil-string isns))))
+                        (process-quil (quil:safely-parse-quil isns))))
                 (num-qubits (cl-quil:qubits-needed quil))
                 (results (perform-multishot *simulation-method* quil num-qubits addresses num-trials
                                             :gate-noise gate-noise
@@ -99,7 +99,7 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
                 (qubits (gethash "qubits" js))
                 (num-trials (gethash "trials" js)))
            (multiple-value-bind (quil relabeling)
-               (process-quil (safely-parse-quil-string
+               (process-quil (quil:safely-parse-quil
                               (get-quil-instrs-field js)))
              (let* ((num-qubits (cl-quil:qubits-needed quil))
                     (results (perform-multishot-measure
@@ -116,9 +116,9 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
         ((:expectation)
          (check-required-fields js "state-preparation" "operators")
          (let* ((quil:*allow-unresolved-applications* t)
-                (state-prep (safely-parse-quil-string
+                (state-prep (quil:safely-parse-quil
                              (gethash "state-preparation" js)))
-                (operators (map 'list #'safely-parse-quil-string
+                (operators (map 'list #'quil:safely-parse-quil
                                 (gethash "operators" js)))
                 (num-qubits (loop :for p :in (cons state-prep operators)
                                   :maximize (cl-quil:qubits-needed p)))
@@ -133,7 +133,7 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
          (check-for-quil-instrs-field js)
          (let* ((isns (get-quil-instrs-field js))
                 (quil (let ((quil:*allow-unresolved-applications* t))
-                        (process-quil (safely-parse-quil-string isns))))
+                        (process-quil (quil:safely-parse-quil isns))))
                 (num-qubits (cl-quil:qubits-needed quil)))
            (let ((qvm (perform-wavefunction *simulation-method* quil num-qubits
                                             :gate-noise gate-noise
@@ -155,7 +155,7 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
          (check-for-quil-instrs-field js)
          (let* ((isns (get-quil-instrs-field js))
                 (quil (let ((quil:*allow-unresolved-applications* t))
-                        (process-quil (safely-parse-quil-string isns))))
+                        (process-quil (quil:safely-parse-quil isns))))
                 (num-qubits (cl-quil:qubits-needed quil)))
            (let (send-response-time)
              (multiple-value-bind (qvm probabilities)
@@ -178,7 +178,7 @@ The mapping vector V specifies that the qubit as specified in the program V[i] h
          (check-for-quil-instrs-field js)
          (let* ((isns (get-quil-instrs-field js))
                 (quil (let ((quil:*allow-unresolved-applications* t))
-                        (process-quil (safely-parse-quil-string isns))))
+                        (process-quil (quil:safely-parse-quil isns))))
                 (num-qubits (cl-quil:qubits-needed quil)))
            (perform-run-for-effect *simulation-method* quil num-qubits
                                    :gate-noise gate-noise

--- a/app/tests/suite.lisp
+++ b/app/tests/suite.lisp
@@ -75,7 +75,7 @@ I 2")
   "Test that we handle out-of-bounds measurements correctly, even with relabelings."
   ;; Version #1
   (multiple-value-bind (p relabeling) (qvm-app::process-quil
-                                       (qvm-app::safely-parse-quil-string "X 0"))
+                                       (quil:safely-parse-quil "X 0"))
     ;; Case 1.A. We have a relabeling, and the thing appropriately
     ;; handles it.
     (let ((answer (mute
@@ -89,7 +89,7 @@ I 2")
       (mute
         (qvm-app::perform-multishot-measure 'qvm-app::pure-state p 1 '(0 1) 10 nil))))
   ;; Version #2
-  (let* ((p (qvm-app::safely-parse-quil-string "X 0"))
+  (let* ((p (quil:safely-parse-quil "X 0"))
          (q (qvm:make-qvm (quil::qubits-needed p))))
     (qvm:load-program q p)
     (qvm:run q)
@@ -97,7 +97,7 @@ I 2")
 
 (deftest test-multishot-measure-disjoint-measurement-qubits ()
   (dolist (simulation-method '(qvm-app::pure-state  qvm-app::full-density-matrix))
-    (let ((quil (qvm-app::safely-parse-quil-string "X 0")))
+    (let ((quil (quil:safely-parse-quil "X 0")))
       (let ((answer (mute
                       ;; measure qubits 1 and 2 which have not been
                       ;; affected by program
@@ -110,7 +110,7 @@ I 2")
 
 (deftest test-multishot-simulation-methods ()
   (dolist (simulation-method '(qvm-app::pure-state qvm-app::full-density-matrix))
-    (let ((quil (qvm-app::safely-parse-quil-string
+    (let ((quil (quil:safely-parse-quil
                  "DECLARE ro BIT[1]
 X 0
 MEASURE 0 ro[0]"))
@@ -127,8 +127,8 @@ MEASURE 0 ro[0]"))
 
 (deftest test-expectation-hadamard-plus ()
   (dolist (simulation-method '(qvm-app::pure-state qvm-app::full-density-matrix))
-    (let ((state-prep (qvm-app::safely-parse-quil-string "H 0")) ; we are in the |+> state
-          (ops (mapcar #'qvm-app::safely-parse-quil-string
+    (let ((state-prep (quil:safely-parse-quil "H 0")) ; we are in the |+> state
+          (ops (mapcar #'quil:safely-parse-quil
                        (list "X 0"
                              "Y 0"
                              "Z 0"))))
@@ -140,9 +140,9 @@ MEASURE 0 ro[0]"))
 
 (deftest test-expectation-hadamard-minus ()
   (dolist (simulation-method '(qvm-app::pure-state qvm-app::full-density-matrix))
-    (let ((state-prep (qvm-app::safely-parse-quil-string "X 0
+    (let ((state-prep (quil:safely-parse-quil "X 0
 H 0")) ; we are in the |-> state
-          (ops (mapcar #'qvm-app::safely-parse-quil-string
+          (ops (mapcar #'quil:safely-parse-quil
                        (list "X 0"
                              "Y 0"
                              "Z 0"))))
@@ -155,8 +155,8 @@ H 0")) ; we are in the |-> state
 
 (deftest test-expectation-mixed-op ()
   (dolist (simulation-method '(qvm-app::pure-state qvm-app::full-density-matrix))
-    (let ((state-prep (qvm-app::safely-parse-quil-string "H 0"))
-          (ops (list (qvm-app::safely-parse-quil-string "X 0
+    (let ((state-prep (quil:safely-parse-quil "H 0"))
+          (ops (list (quil:safely-parse-quil "X 0
 Y 1"))))
       (let ((answer (mute
                       ;; we run on 5 qubits, just to make sure matrices are forced

--- a/examples/qaoa.lisp
+++ b/examples/qaoa.lisp
@@ -67,9 +67,10 @@ GRAPH should be a list of edges, each represented as a pair (A B) of integer ver
 
 (defun cut-weight (graph cut)
   "Given a graph GRAPH and a cut (a list of vertices), compute the cut weight."
-  (loop :for (from to) :in graph
-        :sum (logxor (ldb (byte 1 from) cut)
-                     (ldb (byte 1 to) cut))))
+  (let ((val (loop :for (from to) :in graph
+                   :sum (logxor (ldb (byte 1 from) cut)
+                                (ldb (byte 1 to) cut)))))
+    val))
 
 ;;; Test fixtures
 

--- a/examples/qaoa.lisp
+++ b/examples/qaoa.lisp
@@ -67,10 +67,9 @@ GRAPH should be a list of edges, each represented as a pair (A B) of integer ver
 
 (defun cut-weight (graph cut)
   "Given a graph GRAPH and a cut (a list of vertices), compute the cut weight."
-  (let ((val (loop :for (from to) :in graph
-                   :sum (logxor (ldb (byte 1 from) cut)
-                                (ldb (byte 1 to) cut)))))
-    val))
+  (loop :for (from to) :in graph
+        :sum (logxor (ldb (byte 1 from) cut)
+                     (ldb (byte 1 to) cut))))
 
 ;;; Test fixtures
 


### PR DESCRIPTION
Apologies for this late PR. This removes some code duplication by using directly cl-quil's functions for safe resolution of include files.