### PR TITLE
Bump cl-quil dependency in qvm-app.asd

### DIFF
--- a/qvm-app.asd
+++ b/qvm-app.asd
@@ -9,7 +9,7 @@
   :version (:read-file-form "VERSION.txt")
   :depends-on (
                ;; Quil parsing
-               (:version #:cl-quil "1.11.0")
+               (:version #:cl-quil "1.15.0")
                ;; Command line argument parsing
                #:command-line-arguments
                ;; ASDF-companion utility library


### PR DESCRIPTION
Update qvm-app cl-quil dep to match that of qvm since qvm-app now depends on `cl-quil:safely-parse-quil`