### PR TITLE
Wrap variable in quotes, in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ RIGETTI_LISP_LIBRARY_HOME=../
 SBCL_BIN=sbcl
 SBCL=$(SBCL_BIN) --dynamic-space-size $(QVM_WORKSPACE) --noinform --non-interactive --no-userinit --no-sysinit
 
-QUICKLISP_HOME=$(HOME)/quicklisp
+QUICKLISP_HOME ?= $(HOME)/quicklisp
 QUICKLISP_SETUP=$(QUICKLISP_HOME)/setup.lisp
 QUICKLISP=$(SBCL) --load $(QUICKLISP_HOME)/setup.lisp \
 	--eval '(push (truename ".") asdf:*central-registry*)' \
@@ -170,7 +170,7 @@ clean-cache:
 	@echo "Deleting $(LISP_CACHE)"
 	$(QUICKLISP) \
              --eval "(ql:register-local-projects)"
-	rm -rf $(LISP_CACHE)
+	rm -rf "$(LISP_CACHE)"
 
 clean-quicklisp:
 	@echo "Cleaning up old projects in Quicklisp"


### PR DESCRIPTION
I'm not *entirely* sure why I was seeing the following behaviour, but this PR fixes it.

At the top of `Makefile`, `$LISP_CACHE` is defined using backtick notation. Later, in the `clean-cache` target, `$LISP_CACHE` is used twice: once in an `echo`, and once in a `rm`. In the `echo`, the path is displayed properly, but in the `rm` it looks like the backticks are not evaluated, and instead the command is ``rm `sbcl ...` `` which results in an error.