### PR TITLE
WAIT!

### DIFF
--- a/doc/man/qvm.1
+++ b/doc/man/qvm.1
@@ -344,8 +344,6 @@ Shared memory mode does not work with QVMs executing noisy programs
 (i.e., ones where Kraus operators or POVMs are specified).
 
 The allocation mode is not reflected in density matrix simulations.
-
-The WAIT instruction does nothing.
 .SH SUPPORT
 Contact <support@rigetti.com> or Robert Smith <robert@rigetti.com>.
 .SH COPYRIGHT

--- a/src/classical-memory-mixin.lisp
+++ b/src/classical-memory-mixin.lisp
@@ -4,6 +4,10 @@
 
 (in-package #:qvm)
 
+(defun warning-wait-function (qvm)
+  (declare (ignore qvm))
+  (warn "WAIT executed. Nothing to wait on."))
+
 ;;; The non-quantum parts of a QVM (the program, the pc, and the
 ;;; classical memory subsystem) don't really change from QVM to QVM,
 ;;; so that state is stored in an abstract mixin class.
@@ -22,11 +26,15 @@
    (program :accessor program
             :initform #()
             :documentation "The program to be executed.")
+   (wait-function :reader wait-function
+                  :initarg :wait-function
+                  :documentation "A unary function taking a QVM and implementing Quil's WAIT logic. (The default does nothing and just warns.)")
    (gate-definitions :accessor gate-definitions
                      :initarg :gate-definitions
                      :documentation "A table mapping gate names to their GATE-instance definition."))
   (:default-initargs
    :classical-memory-subsystem (make-instance 'qvm:classical-memory-subsystem)
+   :wait-function 'warning-wait-function
    ;; XXX FIXME: To be superseded by some notion of environments.
    :gate-definitions (copy-hash-table quil::**default-gate-definitions**))
   (:metaclass abstract-class)

--- a/src/transition-classical-instructions.lisp
+++ b/src/transition-classical-instructions.lisp
@@ -373,3 +373,11 @@
   quil:classical-greater-equal-bit/octet/immediate
   quil:classical-greater-equal-bit/integer/immediate
   quil:classical-greater-equal-bit/real/immediate)
+
+;;; WAIT!
+
+(defmethod transition ((qvm classical-memory-mixin) (instr quil:wait))
+  (declare (ignore instr))
+  (funcall (wait-function qvm) qvm)
+  (incf (pc qvm))
+  qvm)

--- a/src/transition.lisp
+++ b/src/transition.lisp
@@ -94,13 +94,6 @@ Return just the resulting (possibly modified) QVM after executing INSTR. (Histor
       (setf (pc qvm) (1+ (pc measured-qvm)))
       qvm)))
 
-(defmethod transition ((qvm classical-memory-mixin) (instr quil:wait))
-  (declare (ignore instr))
-  (when *transition-verbose*
-    (warn "WAIT executed. Nothing to wait on."))
-  (incf (pc qvm))
-  qvm)
-
 
 ;;;;;;;;;;;;;;;;;;;; JUMP, JUMP-WHEN, JUMP-UNLESS ;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Add a `WAIT-FUNCTION` slot to `CLASSICAL-MEMORY-MIXIN` that defaults to `WARNING-WAIT-FUNCTION`, and call it in `TRANSITION` specialized on `((QVM CLASSICAL-MEMORY-MIXIN) (INSTR QUIL:WAIT))`.

This was originally implemented as part of work on implementing `WAIT` for persistent qvms, but factored out into a separate commit here.

This commit brought to you by the STYLEWARNING FOUNDATION FOR QVM EMPOWERMENT AND CLASSICAL COMMUNITY SIMULATION.