### PR TITLE
Only disallow SSL for SDK builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ QUICKLISP_SETUP=$(QUICKLISP_HOME)/setup.lisp
 QUICKLISP=$(SBCL) --load $(QUICKLISP_HOME)/setup.lisp \
 	--eval '(push (truename ".") asdf:*central-registry*)' \
 	--eval '(push :hunchentoot-no-ssl *features*)' \
-	--eval '(push :drakma-no-ssl *features*)' \
 	--eval "(push (truename \"$(RIGETTI_LISP_LIBRARY_HOME)\") ql:*local-project-directories*)" \
 	$(QVM_FEATURE_FLAGS)
 
@@ -69,7 +68,6 @@ qvm: system-index.txt
 	$(SBCL) $(FOREST_SDK_FEATURE) \
 	        --eval "(setf sb-ext:\*on-package-variance\* '(:warn (:swank :swank-backend :swank-repl) :error t))" \
 		--eval '(push :hunchentoot-no-ssl *features*)' \
-		--eval '(push :drakma-no-ssl *features*)' \
 		$(QVM_FEATURE_FLAGS) \
 		--load build-app.lisp \
                 $(FOREST_SDK_OPTION)
@@ -81,7 +79,8 @@ qvm-ng: system-index.txt
 		--load build-app-ng.lisp \
 		$(FOREST_SDK_OPTION)
 
-qvm-sdk-base: FOREST_SDK_FEATURE=--eval '(pushnew :forest-sdk *features*)'
+qvm-sdk-base: FOREST_SDK_FEATURE=--eval '(pushnew :forest-sdk *features*)' \
+	--eval '(push :drakma-no-ssl *features*)'
 qvm-sdk-base: QVM_WORKSPACE=10240
 qvm-sdk-base: clean clean-cache qvm
 

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -7,7 +7,7 @@
   (error "This file is meant to be loaded."))
 
 (pushnew :hunchentoot-no-ssl *features*)
-(pushnew :drakma-no-ssl *features*)
+#+forest-sdk (pushnew :drakma-no-ssl *features*)
 
 (require 'asdf)
 


### PR DESCRIPTION
This prevents the annoying situation where you've loaded e.g. drakma in your REPL with SSL enabled, and after that when you try to compile quilc you get the error about being unable to find the CL+SSL package.

Same change was made to quilc.

Closes #72.