### PR TITLE
Create PREFIX/bin/ dir during `make install` if does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,9 @@ docker-sdk-barebones: docker
 
  .PHONY: install
 install: qvm qvm-ng
-	install qvm $(DESTDIR)$(PREFIX)/bin
-	install qvm-ng $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install qvm $(DESTDIR)$(PREFIX)/bin/
+	install qvm-ng $(DESTDIR)$(PREFIX)/bin/
 
  .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
When attempting an install of QVM with a custom value for the PREFIX variable, the installation command assumes that `$(DESTDIR)$(PREFIX)/bin` exists. However, this is may not always be the case, leaving the `qvm` and `qvm-ng` binaries being copied to `$(DESTDIR)$(PREFIX)/` as `bin`-named binaries, overwriting one another respectively.

As a fix for this, I have added a line to create the required `bin` directory if it does not yet exist. For installations into existing PREFIX directories (e.g `/usr/local/`) there will be no change, but for `PREFIX` dirs without a `bin` directory one will be created before installing the binaries.
