### PR TITLE
Fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG build_target
 # build the qvm app
 ADD . /src/qvm
 WORKDIR /src/qvm
-RUN git clean -fdx && make ${build_target} && make install
+RUN git clean -fdx && make ${build_target} install
 
 EXPOSE 5000
 


### PR DESCRIPTION
This was an oopsie. The `make install` was being treated as a separate build, not inheriting the appropriate `${build_target}` and so it was re-built and then installed as a standard non-sdk build.